### PR TITLE
Add graph DSL interpreter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ test = false
 
 [dependencies]
 regex = "1"
+smallvec = { version="1.6", features=["union"] }
 thiserror = "1.0"
 tree-sitter = "0.19"
 
@@ -26,4 +27,5 @@ default-features = false
 features = ["std", "inline-more", "backends"]
 
 [dev-dependencies]
+indoc = "1.0"
 tree-sitter-python = "0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2018"
 test = false
 
 [dependencies]
+anyhow = "1.0"
 regex = "1"
 smallvec = { version="1.6", features=["union"] }
 thiserror = "1.0"

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -100,6 +100,11 @@ impl Functions {
         functions.add(ctx.add_identifier("start-column"), stdlib::StartColumn);
         functions.add(ctx.add_identifier("end-row"), stdlib::EndRow);
         functions.add(ctx.add_identifier("end-column"), stdlib::EndColumn);
+        functions.add(ctx.add_identifier("node-type"), stdlib::NodeType);
+        functions.add(
+            ctx.add_identifier("named-child-count"),
+            stdlib::NamedChildCount,
+        );
         functions
     }
 
@@ -303,6 +308,41 @@ pub mod stdlib {
             let node = parameters.param()?.into_syntax_node(graph)?;
             parameters.finish()?;
             Ok(Value::Integer(node.end_position().column as u32))
+        }
+    }
+
+    // The implementation of the standard [`node-type`][`crate::reference::functions#node-type`]
+    // function.
+    pub struct NodeType;
+
+    impl Function for NodeType {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let node = parameters.param()?.into_syntax_node(graph)?;
+            parameters.finish()?;
+            Ok(Value::String(node.kind().to_string()))
+        }
+    }
+
+    // The implementation of the standard
+    // [`named-child-count`][`crate::reference::functions#named-child-count`] function.
+
+    pub struct NamedChildCount;
+
+    impl Function for NamedChildCount {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let node = parameters.param()?.into_syntax_node(graph)?;
+            parameters.finish()?;
+            Ok(Value::Integer(node.named_child_count() as u32))
         }
     }
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,0 +1,235 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Functions that can be called by graph DSL files
+
+use std::collections::HashMap;
+
+use crate::execution::ExecutionError;
+use crate::graph::Graph;
+use crate::graph::Value;
+use crate::Context;
+use crate::Identifier;
+
+/// The implementation of a function that can be called from the graph DSL.
+///
+/// You have access to the graph, as it has been constructed up to the point of the function call,
+/// as well as the text content of the source file that's being processed.
+///
+/// Any other data that you need must be passed in as a parameter to the function.  You can use the
+/// [`Parameters`][] trait to consume those parameters and verify that you received the correct
+/// number and type of them.
+pub trait Function {
+    fn call(
+        &mut self,
+        graph: &mut Graph,
+        source: &str,
+        parameters: &mut dyn Parameters,
+    ) -> Result<Value, ExecutionError>;
+}
+
+/// A helper trait for consuming the parameters of a function.  You will typically use it as
+/// follows:
+///
+/// ```
+/// # use tree_sitter_graph::functions::Parameters;
+/// # use tree_sitter_graph::graph::Value;
+/// # use tree_sitter_graph::ExecutionError;
+/// # fn main() -> Result<(), ExecutionError> {
+/// # let param_vec = vec![Value::String("test".to_string()), Value::Integer(42)];
+/// # let mut params = param_vec.into_iter();
+/// let first_param = params.param()?.into_string()?;
+/// let second_param = params.param()?.into_integer()?;
+/// // etc
+/// params.finish()?;
+/// # Ok(())
+/// # }
+/// ```
+pub trait Parameters {
+    /// Returns the next parameter, returning an error if you have exhausted all of the parameters
+    /// that were passed in.
+    fn param(&mut self) -> Result<Value, ExecutionError>;
+
+    /// Ensures that there are no more parameters to consume.
+    fn finish(&mut self) -> Result<(), ExecutionError>;
+}
+
+impl<I> Parameters for I
+where
+    I: Iterator<Item = Value>,
+{
+    fn param(&mut self) -> Result<Value, ExecutionError> {
+        let value = self.next().ok_or(ExecutionError::InvalidParameters)?;
+        Ok(value)
+    }
+
+    fn finish(&mut self) -> Result<(), ExecutionError> {
+        if self.next().is_some() {
+            return Err(ExecutionError::InvalidParameters);
+        }
+        Ok(())
+    }
+}
+
+/// A library of named functions.
+#[derive(Default)]
+pub struct Functions {
+    functions: HashMap<Identifier, Box<dyn Function>>,
+}
+
+impl Functions {
+    /// Creates a new, empty library of functions.
+    pub fn new() -> Functions {
+        Functions::default()
+    }
+
+    /// Returns the standard library of functions, as defined in the [language
+    /// reference][`crate::reference::functions`].
+    pub fn stdlib(ctx: &mut Context) -> Functions {
+        let mut functions = Functions::new();
+        functions.add(ctx.add_identifier("child-index"), stdlib::ChildIndex);
+        functions.add(ctx.add_identifier("node"), stdlib::Node);
+        functions.add(ctx.add_identifier("plus"), stdlib::Plus);
+        functions.add(ctx.add_identifier("replace"), stdlib::Replace);
+        functions.add(ctx.add_identifier("source-text"), stdlib::SourceText);
+        functions
+    }
+
+    /// Adds a new function to this library.
+    pub fn add<F>(&mut self, name: Identifier, function: F)
+    where
+        F: Function + 'static,
+    {
+        self.functions.insert(name, Box::new(function));
+    }
+
+    /// Calls a named function, returning an error if there is no function with that name.
+    pub fn call(
+        &mut self,
+        name: Identifier,
+        graph: &mut Graph,
+        source: &str,
+        parameters: &mut dyn Parameters,
+    ) -> Result<Value, ExecutionError> {
+        let function = self
+            .functions
+            .get_mut(&name)
+            .ok_or(ExecutionError::UndefinedFunction)?;
+        function.call(graph, source, parameters)
+    }
+}
+
+/// Implementations of the [standard library functions][`crate::reference::functions`]
+pub mod stdlib {
+    use anyhow::anyhow;
+    use regex::Regex;
+
+    use crate::execution::ExecutionError;
+    use crate::graph::Graph;
+    use crate::graph::Value;
+
+    use super::Function;
+    use super::Parameters;
+
+    /// The implementation of the standard [`child-index`][`crate::reference::functions#child-index`]
+    /// function.
+    pub struct ChildIndex;
+
+    impl Function for ChildIndex {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let node = parameters.param()?.into_syntax_node(graph)?;
+            parameters.finish()?;
+            let parent = match node.parent() {
+                Some(parent) => parent,
+                None => return Err(anyhow!("Cannot call child-index on the root node").into()),
+            };
+            let mut tree_cursor = parent.walk();
+            let index = parent
+                .named_children(&mut tree_cursor)
+                .position(|child| child == *node)
+                .ok_or(anyhow!("Called child-index on a non-named child"))?;
+            Ok(Value::Integer(index as u32))
+        }
+    }
+
+    /// The implementation of the standard [`node`][`crate::reference::functions#node`] function.
+    pub struct Node;
+
+    impl Function for Node {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            parameters.finish()?;
+            let node = graph.add_graph_node();
+            Ok(Value::GraphNode(node))
+        }
+    }
+
+    /// The implementation of the standard [`plus`][`crate::reference::functions#plus`] function.
+    pub struct Plus;
+
+    impl Function for Plus {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let mut result = 0;
+            while let Ok(parameter) = parameters.param() {
+                result += parameter.into_integer()?;
+            }
+            Ok(Value::Integer(result))
+        }
+    }
+
+    /// The implementation of the standard [`replace`][`crate::reference::functions#replace`] function.
+    pub struct Replace;
+
+    impl Function for Replace {
+        fn call(
+            &mut self,
+            _graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let text = parameters.param()?.into_string()?;
+            let pattern = parameters.param()?.into_string()?;
+            let pattern = Regex::new(&pattern).map_err(ExecutionError::other)?;
+            let replacement = parameters.param()?.into_string()?;
+            parameters.finish()?;
+            Ok(Value::String(
+                pattern.replace_all(&text, replacement).to_string(),
+            ))
+        }
+    }
+
+    /// The implementation of the standard [`source-text`][`crate::reference::functions#source-text`]
+    /// function.
+    pub struct SourceText;
+
+    impl Function for SourceText {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let node = parameters.param()?.into_syntax_node(graph)?;
+            parameters.finish()?;
+            Ok(Value::String(source[node.byte_range()].to_string()))
+        }
+    }
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -250,7 +250,7 @@ pub mod stdlib {
         ) -> Result<Value, ExecutionError> {
             let node = parameters.param()?.into_syntax_node(graph)?;
             parameters.finish()?;
-            Ok(Value::String(node.start_position().row.to_string()))
+            Ok(Value::Integer(node.start_position().row as u32))
         }
     }
 
@@ -268,7 +268,7 @@ pub mod stdlib {
         ) -> Result<Value, ExecutionError> {
             let node = parameters.param()?.into_syntax_node(graph)?;
             parameters.finish()?;
-            Ok(Value::String(node.start_position().column.to_string()))
+            Ok(Value::Integer(node.start_position().column as u32))
         }
     }
 
@@ -285,7 +285,7 @@ pub mod stdlib {
         ) -> Result<Value, ExecutionError> {
             let node = parameters.param()?.into_syntax_node(graph)?;
             parameters.finish()?;
-            Ok(Value::String(node.end_position().row.to_string()))
+            Ok(Value::Integer(node.end_position().row as u32))
         }
     }
 
@@ -302,7 +302,7 @@ pub mod stdlib {
         ) -> Result<Value, ExecutionError> {
             let node = parameters.param()?.into_syntax_node(graph)?;
             parameters.finish()?;
-            Ok(Value::String(node.end_position().column.to_string()))
+            Ok(Value::Integer(node.end_position().column as u32))
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,343 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines data types for the graphs produced by the graph DSL
+
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::ops::Index;
+use std::ops::IndexMut;
+
+use smallvec::SmallVec;
+use tree_sitter::Node;
+
+use crate::Context;
+use crate::Identifier;
+
+/// A graph produced by executing a graph DSL file.  Graphs include a lifetime parameter to ensure
+/// that they don't outlive the tree-sitter syntax tree that they are generated from.
+#[derive(Default)]
+pub struct Graph<'tree> {
+    syntax_nodes: HashMap<SyntaxNodeRef, Node<'tree>>,
+    graph_nodes: Vec<GraphNode>,
+}
+
+type SyntaxNodeID = u32;
+type GraphNodeID = u32;
+
+impl<'tree> Graph<'tree> {
+    /// Creates a new, empty graph.
+    pub fn new() -> Graph<'tree> {
+        Graph::default()
+    }
+
+    /// Adds a syntax node to the graph, returning a graph DSL reference to it.
+    ///
+    /// The graph won't contain _every_ syntax node in the parsed syntax tree; it will only contain
+    /// those nodes that are referenced at some point during the execution of the graph DSL file.
+    pub fn add_syntax_node(&mut self, node: Node<'tree>) -> SyntaxNodeRef {
+        let index = SyntaxNodeRef(node.id() as SyntaxNodeID);
+        self.syntax_nodes.insert(index, node);
+        index
+    }
+
+    /// Adds a new graph node to the graph, returning a graph DSL reference to it.
+    pub fn add_graph_node(&mut self) -> GraphNodeRef {
+        let graph_node = GraphNode::new();
+        let index = self.graph_nodes.len() as GraphNodeID;
+        self.graph_nodes.push(graph_node);
+        GraphNodeRef(index)
+    }
+
+    /// Displays the contents of this graph.
+    pub fn display_with<'a>(&'a self, ctx: &'a Context) -> impl Display + 'a {
+        struct DisplayGraph<'a, 'tree>(&'a Graph<'tree>, &'a Context);
+
+        impl<'a, 'tree> Display for DisplayGraph<'a, 'tree> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                let graph = self.0;
+                let ctx = self.1;
+                for (node_index, node) in graph.graph_nodes.iter().enumerate() {
+                    write!(
+                        f,
+                        "node {}\n{}",
+                        node_index,
+                        node.attributes.display_with(ctx, graph)
+                    )?;
+                    for (sink, edge) in &node.outgoing_edges {
+                        write!(
+                            f,
+                            "edge {} -> {}\n{}",
+                            node_index,
+                            *sink,
+                            edge.attributes.display_with(ctx, graph)
+                        )?;
+                    }
+                }
+                Ok(())
+            }
+        }
+
+        DisplayGraph(self, ctx)
+    }
+}
+
+impl<'tree> Index<SyntaxNodeRef> for Graph<'tree> {
+    type Output = Node<'tree>;
+    fn index(&self, index: SyntaxNodeRef) -> &Node<'tree> {
+        &self.syntax_nodes[&index]
+    }
+}
+
+impl Index<GraphNodeRef> for Graph<'_> {
+    type Output = GraphNode;
+    fn index(&self, index: GraphNodeRef) -> &GraphNode {
+        &self.graph_nodes[index.0 as usize]
+    }
+}
+
+impl<'tree> IndexMut<GraphNodeRef> for Graph<'_> {
+    fn index_mut(&mut self, index: GraphNodeRef) -> &mut GraphNode {
+        &mut self.graph_nodes[index.0 as usize]
+    }
+}
+
+/// A node in a graph
+pub struct GraphNode {
+    outgoing_edges: SmallVec<[(GraphNodeID, Edge); 8]>,
+    /// The set of attributes associated with this graph node
+    pub attributes: Attributes,
+}
+
+impl GraphNode {
+    fn new() -> GraphNode {
+        GraphNode {
+            outgoing_edges: SmallVec::new(),
+            attributes: Attributes::new(),
+        }
+    }
+
+    /// Adds an edge to this node.  There can be at most one edge connecting any two graph nodes;
+    /// the result indicates whether the edge is new (`Ok`) or already existed (`Err`).  In either
+    /// case, you also get a mutable reference to the [`Edge`][] instance for the edge.
+    pub fn add_edge(&mut self, sink: GraphNodeRef) -> Result<&mut Edge, &mut Edge> {
+        let sink = sink.0;
+        match self
+            .outgoing_edges
+            .binary_search_by_key(&sink, |(sink, _)| *sink)
+        {
+            Ok(index) => Err(&mut self.outgoing_edges[index].1),
+            Err(index) => {
+                self.outgoing_edges.insert(index, (sink, Edge::new()));
+                Ok(&mut self.outgoing_edges[index].1)
+            }
+        }
+    }
+
+    /// Returns a reference to an outgoing edge from this node, if it exists.
+    pub fn get_edge(&self, sink: GraphNodeRef) -> Option<&Edge> {
+        let sink = sink.0;
+        self.outgoing_edges
+            .binary_search_by_key(&sink, |(sink, _)| *sink)
+            .ok()
+            .map(|index| &self.outgoing_edges[index].1)
+    }
+
+    /// Returns a mutable reference to an outgoing edge from this node, if it exists.
+    pub fn get_edge_mut(&mut self, sink: GraphNodeRef) -> Option<&mut Edge> {
+        let sink = sink.0;
+        self.outgoing_edges
+            .binary_search_by_key(&sink, |(sink, _)| *sink)
+            .ok()
+            .map(move |index| &mut self.outgoing_edges[index].1)
+    }
+}
+
+/// An edge between two nodes in a graph
+pub struct Edge {
+    /// The set of attributes associated with this edge
+    pub attributes: Attributes,
+}
+
+impl Edge {
+    fn new() -> Edge {
+        Edge {
+            attributes: Attributes::new(),
+        }
+    }
+}
+
+/// A set of attributes associated with a graph node or edge
+pub struct Attributes {
+    values: SmallVec<[(Identifier, Value); 8]>,
+}
+
+impl Attributes {
+    /// Creates a new, empty set of attributes.
+    pub fn new() -> Attributes {
+        Attributes {
+            values: SmallVec::new(),
+        }
+    }
+
+    /// Adds an attribute to this attribute set.  If there was already an attribute with the same
+    /// name, replaces its value and returns `Err`.
+    pub fn add<V: Into<Value>>(&mut self, name: Identifier, value: V) -> Result<(), ()> {
+        match self.values.binary_search_by_key(&name, |(name, _)| *name) {
+            Ok(_) => Err(()),
+            Err(index) => {
+                self.values.insert(index, (name, value.into()));
+                Ok(())
+            }
+        }
+    }
+
+    /// Returns the value of a particular attribute, if it exists.
+    pub fn get(&self, name: Identifier) -> Option<&Value> {
+        self.values
+            .binary_search_by_key(&name, |(name, _)| *name)
+            .ok()
+            .map(|index| &self.values[index].1)
+    }
+
+    /// Displays the contents of this attribute set.
+    pub fn display_with<'a>(&'a self, ctx: &'a Context, graph: &'a Graph) -> impl Display + 'a {
+        struct DisplayAttributes<'a, 'tree>(&'a Attributes, &'a Context, &'a Graph<'tree>);
+
+        impl<'a, 'tree> Display for DisplayAttributes<'a, 'tree> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                let attributes = self.0;
+                let ctx = self.1;
+                let graph = self.2;
+                for (name, value) in &attributes.values {
+                    write!(
+                        f,
+                        "  {}: {}\n",
+                        ctx.resolve(*name),
+                        value.display_with(graph),
+                    )?;
+                }
+                Ok(())
+            }
+        }
+
+        DisplayAttributes(self, ctx, graph)
+    }
+}
+
+/// The value of an attribute
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Value {
+    // Scalar
+    Null,
+    Boolean(bool),
+    Integer(u32),
+    String(String),
+    // Compound
+    List(Vec<Value>),
+    Set(BTreeSet<Value>),
+    // References
+    SyntaxNode(SyntaxNodeRef),
+    GraphNode(GraphNodeRef),
+}
+
+impl Value {
+    /// Displays this value.
+    pub fn display_with<'a, 'tree>(&'a self, graph: &'a Graph<'tree>) -> impl Display + 'a {
+        struct DisplayValue<'a, 'tree>(&'a Value, &'a Graph<'tree>);
+
+        impl<'a, 'tree> Display for DisplayValue<'a, 'tree> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                let graph = self.1;
+                match self.0 {
+                    Value::Null => write!(f, "#null"),
+                    Value::Boolean(value) => {
+                        if *value {
+                            write!(f, "#true")
+                        } else {
+                            write!(f, "#false")
+                        }
+                    }
+                    Value::Integer(value) => write!(f, "{}", value),
+                    Value::String(value) => write!(f, "{}", value),
+                    Value::List(value) => {
+                        write!(f, "[")?;
+                        let mut first = true;
+                        for element in value {
+                            if first {
+                                write!(f, "{}", element.display_with(graph))?;
+                                first = false;
+                            } else {
+                                write!(f, ", {}", element.display_with(graph))?;
+                            }
+                        }
+                        write!(f, "]")
+                    }
+                    Value::Set(value) => {
+                        write!(f, "{{")?;
+                        let mut first = true;
+                        for element in value {
+                            if first {
+                                write!(f, "{}", element.display_with(graph))?;
+                                first = false;
+                            } else {
+                                write!(f, ", {}", element.display_with(graph))?;
+                            }
+                        }
+                        write!(f, "}}")
+                    }
+                    Value::SyntaxNode(node) => {
+                        let node = graph[*node];
+                        write!(f, "[syntax node {} {}]", node.kind(), node.start_position())
+                    }
+                    Value::GraphNode(node) => write!(f, "[graph node {}]", node.0),
+                }
+            }
+        }
+
+        DisplayValue(self, graph)
+    }
+}
+
+impl From<u32> for Value {
+    fn from(value: u32) -> Value {
+        Value::Integer(value)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(value: &str) -> Value {
+        Value::String(value.to_string())
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Value {
+        Value::String(value)
+    }
+}
+
+/// A reference to a syntax node in a graph
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SyntaxNodeRef(SyntaxNodeID);
+
+impl From<SyntaxNodeRef> for Value {
+    fn from(value: SyntaxNodeRef) -> Value {
+        Value::SyntaxNode(value)
+    }
+}
+
+/// A reference to a graph node
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct GraphNodeRef(GraphNodeID);
+
+impl From<GraphNodeRef> for Value {
+    fn from(value: GraphNodeRef) -> Value {
+        Value::GraphNode(value)
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -16,6 +16,7 @@ use std::ops::IndexMut;
 use smallvec::SmallVec;
 use tree_sitter::Node;
 
+use crate::execution::ExecutionError;
 use crate::Context;
 use crate::Identifier;
 
@@ -247,6 +248,34 @@ pub enum Value {
 }
 
 impl Value {
+    /// Coerces this value into an integer, returning an error if it's some other type of value.
+    pub fn into_integer(self) -> Result<u32, ExecutionError> {
+        match self {
+            Value::Integer(value) => Ok(value),
+            _ => Err(ExecutionError::ExpectedInteger),
+        }
+    }
+
+    /// Coerces this value into a string, returning an error if it's some other type of value.
+    pub fn into_string(self) -> Result<String, ExecutionError> {
+        match self {
+            Value::String(value) => Ok(value),
+            _ => Err(ExecutionError::ExpectedString),
+        }
+    }
+
+    /// Coerces this value into a syntax node reference, returning an error if it's some other type
+    /// of value.
+    pub fn into_syntax_node<'a, 'tree>(
+        self,
+        graph: &'a Graph<'tree>,
+    ) -> Result<&'a Node<'tree>, ExecutionError> {
+        match self {
+            Value::SyntaxNode(node) => Ok(&graph[node]),
+            _ => Err(ExecutionError::ExpectedSyntaxNode),
+        }
+    }
+
     /// Displays this value.
     pub fn display_with<'a, 'tree>(&'a self, graph: &'a Graph<'tree>) -> impl Display + 'a {
         struct DisplayValue<'a, 'tree>(&'a Value, &'a Graph<'tree>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 pub mod reference;
 
 pub mod ast;
+pub mod graph;
 mod parser;
 
 pub use parser::Location;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,13 @@
 pub mod reference;
 
 pub mod ast;
+mod execution;
+pub mod functions;
 pub mod graph;
 mod parser;
 
+pub use execution::ExecutionError;
+pub use execution::Variables;
 pub use parser::Location;
 pub use parser::ParseError;
 

--- a/src/reference/functions.rs
+++ b/src/reference/functions.rs
@@ -23,7 +23,7 @@
 //!
 //! # Mathematical functions
 //!
-//! ## `+`
+//! ## `plus`
 //!
 //! Adds integers together.
 //!
@@ -63,3 +63,12 @@
 //!
 //! Note that `node` must not refer to the source file's root node, and it must be a _named_ child
 //! of its parent (i.e., it can't be an anonymous leaf node).
+//!
+//! ## `source-text`
+//!
+//! Returns the source text represented by a syntax node.
+//!
+//!   - Input parameters:
+//!     - `node`: A syntax node
+//!   - Output parameter:
+//!     - A string containing the source text represented by `node`

--- a/src/reference/functions.rs
+++ b/src/reference/functions.rs
@@ -61,8 +61,14 @@
 //!     - The index of `node` within its parent's list of _named_ children (i.e., the index that
 //!       would cause `ts_node_named_child` to return `node`)
 //!
-//! Note that `node` must not refer to the source file's root node, and it must be a _named_ child
-//! of its parent (i.e., it can't be an anonymous leaf node).
+//! ## `named-child-count`
+//!
+//! Returns the number of "named children" of a syntax node.
+//!
+//!   - Input parameters:
+//!     - `node`: A syntax node
+//!   - Output parameter:
+//!     - The number of _named_ children in `node`
 //!
 //! ## `source-text`
 //!
@@ -72,6 +78,16 @@
 //!     - `node`: A syntax node
 //!   - Output parameter:
 //!     - A string containing the source text represented by `node`
+//!
+//! ## `node-type`
+//!
+//! Returns a syntax node's type as a string.  (The type is the name of the node's grammar rule in
+//! the underlying tree-sitter grammar.)
+//!
+//!   - Input parameters:
+//!     - `node`: A syntax node
+//!   - Output parameter:
+//!     - A string containing the type of `node`
 //!
 //! ## `start-column`
 //!

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -1,0 +1,178 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use indoc::indoc;
+use tree_sitter::Parser;
+use tree_sitter_graph::ast::File;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::Context;
+use tree_sitter_graph::Variables;
+
+fn check_execution(python_source: &str, dsl_source: &str, expected_graph: &str) {
+    let mut parser = Parser::new();
+    parser.set_language(tree_sitter_python::language()).unwrap();
+    let tree = parser.parse(python_source, None).unwrap();
+    let mut ctx = Context::new();
+    let mut file = File::new(tree_sitter_python::language());
+    file.parse(&mut ctx, dsl_source).expect("Cannot parse file");
+    let mut functions = Functions::stdlib(&mut ctx);
+    let mut globals = Variables::new();
+    let graph = file
+        .execute(&tree, python_source, &mut functions, &mut globals)
+        .expect("Could not execute file");
+    assert_eq!(graph.display_with(&ctx).to_string(), expected_graph);
+}
+
+#[test]
+fn can_build_simple_graph() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            attr (node0) name = "node0", source = @root
+            var node1 = (node)
+            attr (node1) name = "node1"
+            edge node0 -> node1
+            attr (node0 -> node1) precedence = 14
+            node node2
+            attr (node2) name = "node2", parent = node1
+          }
+        "#},
+        indoc! {"
+          node 0
+            name: node0
+            source: [syntax node module (0, 0)]
+          edge 0 -> 1
+            precedence: 14
+          node 1
+            name: node1
+          node 2
+            name: node2
+            parent: [graph node 1]
+        "},
+    );
+}
+
+#[test]
+fn can_scan_strings() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            var new_node = #null
+            var current_node = (node)
+
+            scan "alpha/beta/gamma/delta.py" {
+               "([^/]+)/"
+               {
+                 set new_node = (node)
+                 attr (new_node) name = $1
+                 edge current_node -> new_node
+                 set current_node = new_node
+               }
+
+               "([^/]+)\\.py$"
+               {
+                 set new_node = (node)
+                 attr (new_node) name = $1
+                 edge current_node -> new_node
+               }
+            }
+          }
+        "#},
+        indoc! {"
+          node 0
+          edge 0 -> 1
+          node 1
+            name: alpha
+          edge 1 -> 2
+          node 2
+            name: beta
+          edge 2 -> 3
+          node 3
+            name: gamma
+          edge 3 -> 4
+          node 4
+            name: delta
+        "},
+    );
+}
+
+#[test]
+fn scoped_variables_carry_across_stanzas() {
+    check_execution(
+        indoc! {r#"
+          import a
+          from b import c
+          print(a.d.f)
+        "#},
+        indoc! {r#"
+          (identifier) @id
+          {
+            let @id.node = (node)
+          }
+
+          (identifier) @id
+          {
+            attr (@id.node) name = (source-text @id)
+          }
+        "#},
+        indoc! {"
+          node 0
+            name: a
+          node 1
+            name: b
+          node 2
+            name: c
+          node 3
+            name: print
+          node 4
+            name: a
+          node 5
+            name: d
+          node 6
+            name: f
+        "},
+    );
+}
+
+#[test]
+fn can_match_stanza_multiple_times() {
+    check_execution(
+        indoc! {r#"
+          import a
+          from b import c
+          print(a.d.f)
+        "#},
+        indoc! {r#"
+          (identifier) @id
+          {
+            node new_node
+            attr (new_node) name = (source-text @id)
+          }
+        "#},
+        indoc! {"
+          node 0
+            name: a
+          node 1
+            name: b
+          node 2
+            name: c
+          node 3
+            name: print
+          node 4
+            name: a
+          node 5
+            name: d
+          node 6
+            name: f
+        "},
+    );
+}

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -1,0 +1,68 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use indoc::indoc;
+use tree_sitter::Parser;
+use tree_sitter_graph::graph::Graph;
+use tree_sitter_graph::Context;
+
+#[test]
+fn can_display_graph() {
+    let python_source = "pass";
+    let mut parser = Parser::new();
+    parser.set_language(tree_sitter_python::language()).unwrap();
+    let tree = parser.parse(python_source, None).unwrap();
+
+    let mut ctx = Context::new();
+    let mut graph = Graph::new();
+    let root = graph.add_syntax_node(tree.root_node());
+    let node0 = graph.add_graph_node();
+    graph[node0]
+        .attributes
+        .add(ctx.add_identifier("name"), "node0")
+        .unwrap();
+    graph[node0]
+        .attributes
+        .add(ctx.add_identifier("source"), root)
+        .unwrap();
+    let node1 = graph.add_graph_node();
+    graph[node1]
+        .attributes
+        .add(ctx.add_identifier("name"), "node1")
+        .unwrap();
+    let node2 = graph.add_graph_node();
+    graph[node2]
+        .attributes
+        .add(ctx.add_identifier("name"), "node2")
+        .unwrap();
+    graph[node2]
+        .attributes
+        .add(ctx.add_identifier("parent"), node1)
+        .unwrap();
+    let edge01 = graph[node0]
+        .add_edge(node1)
+        .unwrap_or_else(|_| unreachable!());
+    edge01
+        .attributes
+        .add(ctx.add_identifier("precedence"), 14)
+        .unwrap();
+    assert_eq!(
+        graph.display_with(&ctx).to_string(),
+        indoc! {"
+          node 0
+            name: node0
+            source: [syntax node module (0, 0)]
+          edge 0 -> 1
+            precedence: 14
+          node 1
+            name: node1
+          node 2
+            name: node2
+            parent: [graph node 1]
+        "}
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -5,4 +5,5 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+mod graph;
 mod parser;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -5,5 +5,6 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+mod execution;
 mod graph;
 mod parser;


### PR DESCRIPTION
This patch adds the execution rules for all of the graph DSL constructs, including the standard library of functions.