### PR TITLE
Add initial `tree-sitter-graph` CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,7 @@ jobs:
             ${{ runner.OS }}-cargo-
       - name: Build library
         run: cargo build
+      - name: Build program
+        run: cargo build --bin tree-sitter-graph --features=cli
       - name: Run test suite
         run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,24 @@ features = ["std", "inline-more", "backends"]
 [dev-dependencies]
 indoc = "1.0"
 tree-sitter-python = "0.19.1"
+
+# cli-only dependencies below
+
+[[bin]]
+name = "tree-sitter-graph"
+required-features = ["cli"]
+
+[features]
+cli = ["clap", "tree-sitter-config", "tree-sitter-loader"]
+
+[dependencies.clap]
+optional = true
+version = "2.32"
+
+[dependencies.tree-sitter-config]
+optional = true
+version = "0.19"
+
+[dependencies.tree-sitter-loader]
+optional = true
+version = "0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0"
 regex = "1"
 smallvec = { version="1.6", features=["union"] }
 thiserror = "1.0"
-tree-sitter = "0.19"
+tree-sitter = "0.20"
 
 [dependencies.string-interner]
 version = "0.12"
@@ -29,4 +29,4 @@ features = ["std", "inline-more", "backends"]
 
 [dev-dependencies]
 indoc = "1.0"
-tree-sitter-python = "0.19"
+tree-sitter-python = "0.19.1"

--- a/README.md
+++ b/README.md
@@ -5,18 +5,20 @@ structures from source code that has been parsed using [tree-sitter][].
 
 [tree-sitter]: https://tree-sitter.github.io/
 
-To use this library, add the following to your `Cargo.toml`:
+This package can be used either as a library or command-line program.
+
+To use it as a library, add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
 tree-sitter-graph = "0.0"
 ```
 
-Or install it via `cargo install`:
+To use it as a program, install it via `cargo install`:
 
 ```
 $ cargo install tree-sitter-graph
 ```
 
 Check out our [documentation](https://docs.rs/tree-sitter-graph/) for more
-details on how to use this library.
+details.

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -1,0 +1,65 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::path::Path;
+
+use anyhow::anyhow;
+use anyhow::Context as _;
+use anyhow::Result;
+use clap::App;
+use clap::Arg;
+use tree_sitter::Parser;
+use tree_sitter_config::Config;
+use tree_sitter_graph::ast::File;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::Context;
+use tree_sitter_graph::Variables;
+use tree_sitter_loader::Loader;
+
+const BUILD_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() -> Result<()> {
+    let matches = App::new("tree-sitter-graph")
+        .version(BUILD_VERSION)
+        .author("Douglas Creager <dcreager@dcreager.net>")
+        .about("Generates graph structures from tree-sitter syntax trees")
+        .arg(Arg::with_name("tsg").index(1).required(true))
+        .arg(Arg::with_name("source").index(2).required(true))
+        .arg(Arg::with_name("scope").long("scope").takes_value(true))
+        .get_matches();
+
+    let tsg_path = Path::new(matches.value_of("tsg").unwrap());
+    let source_path = Path::new(matches.value_of("source").unwrap());
+    let current_dir = std::env::current_dir().unwrap();
+    let config = Config::load()?;
+    let mut loader = Loader::new()?;
+    let loader_config = config.get()?;
+    loader.find_all_languages(&loader_config)?;
+    let language = loader.select_language(source_path, &current_dir, matches.value_of("scope"))?;
+    let mut parser = Parser::new();
+    parser.set_language(language)?;
+    let tsg = std::fs::read(tsg_path)
+        .with_context(|| format!("Error reading TSG file {}", tsg_path.display()))?;
+    let tsg = String::from_utf8(tsg)?;
+    let source = std::fs::read(source_path)
+        .with_context(|| format!("Error reading source file {}", source_path.display()))?;
+    let source = String::from_utf8(source)?;
+    let tree = parser
+        .parse(&source, None)
+        .ok_or_else(|| anyhow!("Could not parse {}", source_path.display()))?;
+    let mut ctx = Context::new();
+    let mut file = File::new(language);
+    file.parse(&mut ctx, &tsg)
+        .with_context(|| anyhow!("Error parsing TSG file {}", tsg_path.display()))?;
+    let mut functions = Functions::stdlib(&mut ctx);
+    let mut globals = Variables::new();
+    let graph = file
+        .execute(&tree, &source, &mut functions, &mut globals)
+        .with_context(|| format!("Could not execute TSG file {}", tsg_path.display()))?;
+    print!("{}", graph.display_with(&ctx));
+    Ok(())
+}

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -133,7 +133,7 @@ struct ExecutionContext<'a, 'tree> {
     scoped: &'a mut ScopedVariables,
     current_regex_matches: &'a mut Vec<String>,
     function_parameters: &'a mut Vec<Value>,
-    mat: &'a QueryMatch<'tree>,
+    mat: &'a QueryMatch<'a, 'tree>,
 }
 
 /// An environment of named variables
@@ -231,7 +231,7 @@ impl Stanza {
         function_parameters: &mut Vec<Value>,
         cursor: &mut QueryCursor,
     ) -> Result<(), ExecutionError> {
-        let matches = cursor.matches(&self.query, tree.root_node(), |n| &source[n.byte_range()]);
+        let matches = cursor.matches(&self.query, tree.root_node(), source.as_bytes());
         for mat in matches {
             locals.clear();
             let mut exec = ExecutionContext {


### PR DESCRIPTION
This patch implements a `tree-sitter-graph` CLI program that parses a source file and executes a graph DSL program against it.  It prints out a textual representation of the resulting graph.  In future PRs, we'll look at defining a machine-readable JSON format for the graph.

The CLI program uses tree-sitter's existing logic for determining the language of a source file, and loading its grammar.  It's your responsibility to make sure that the graph DSL program is compatible with that language.