### PR TITLE
Add source locations to statement & stanza AST nodes

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -12,6 +12,7 @@ use tree_sitter::Language;
 use tree_sitter::Query;
 
 use crate::Identifier;
+use crate::Location;
 
 /// A graph DSL file
 #[derive(Debug)]
@@ -37,6 +38,7 @@ pub struct Stanza {
     pub query: Query,
     /// The list of statements in the stanza
     pub statements: Vec<Statement>,
+    pub location: Location,
 }
 
 /// A statement that can appear in a graph DSL stanza
@@ -64,6 +66,7 @@ pub struct AddEdgeAttribute {
     pub source: Expression,
     pub sink: Expression,
     pub attributes: Vec<Attribute>,
+    pub location: Location,
 }
 
 impl From<AddEdgeAttribute> for Statement {
@@ -77,6 +80,7 @@ impl From<AddEdgeAttribute> for Statement {
 pub struct AddGraphNodeAttribute {
     pub node: Expression,
     pub attributes: Vec<Attribute>,
+    pub location: Location,
 }
 
 impl From<AddGraphNodeAttribute> for Statement {
@@ -90,6 +94,7 @@ impl From<AddGraphNodeAttribute> for Statement {
 pub struct Assign {
     pub variable: Variable,
     pub value: Expression,
+    pub location: Location,
 }
 
 impl From<Assign> for Statement {
@@ -110,6 +115,7 @@ pub struct Attribute {
 pub struct CreateEdge {
     pub source: Expression,
     pub sink: Expression,
+    pub location: Location,
 }
 
 impl From<CreateEdge> for Statement {
@@ -122,6 +128,7 @@ impl From<CreateEdge> for Statement {
 #[derive(Debug, Eq, PartialEq)]
 pub struct CreateGraphNode {
     pub node: Variable,
+    pub location: Location,
 }
 
 impl From<CreateGraphNode> for Statement {
@@ -135,6 +142,7 @@ impl From<CreateGraphNode> for Statement {
 pub struct DeclareImmutable {
     pub variable: Variable,
     pub value: Expression,
+    pub location: Location,
 }
 
 impl From<DeclareImmutable> for Statement {
@@ -148,6 +156,7 @@ impl From<DeclareImmutable> for Statement {
 pub struct DeclareMutable {
     pub variable: Variable,
     pub value: Expression,
+    pub location: Location,
 }
 
 impl From<DeclareMutable> for Statement {
@@ -160,6 +169,7 @@ impl From<DeclareMutable> for Statement {
 #[derive(Debug, Eq, PartialEq)]
 pub struct Print {
     pub values: Vec<Expression>,
+    pub location: Location,
 }
 
 impl From<Print> for Statement {
@@ -173,6 +183,7 @@ impl From<Print> for Statement {
 pub struct Scan {
     pub value: Expression,
     pub arms: Vec<ScanArm>,
+    pub location: Location,
 }
 
 impl From<Scan> for Statement {
@@ -186,6 +197,7 @@ impl From<Scan> for Statement {
 pub struct ScanArm {
     pub regex: Regex,
     pub statements: Vec<Statement>,
+    pub location: Location,
 }
 
 impl Eq for ScanArm {}

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -7,6 +7,7 @@
 
 use tree_sitter_graph::ast::*;
 use tree_sitter_graph::Context;
+use tree_sitter_graph::Location;
 
 #[test]
 fn can_parse_blocks() {
@@ -43,7 +44,11 @@ fn can_parse_blocks() {
     assert_eq!(
         statements,
         vec![vec![
-            CreateGraphNode { node: loc1.into() }.into(),
+            CreateGraphNode {
+                node: loc1.into(),
+                location: Location { row: 4, column: 10 }
+            }
+            .into(),
             CreateGraphNode {
                 node: ScopedVariable {
                     scope: Box::new(
@@ -56,6 +61,7 @@ fn can_parse_blocks() {
                     name: prop1,
                 }
                 .into(),
+                location: Location { row: 5, column: 10 },
             }
             .into(),
             CreateEdge {
@@ -71,6 +77,7 @@ fn can_parse_blocks() {
                 }
                 .into(),
                 sink: loc1.into(),
+                location: Location { row: 6, column: 10 },
             }
             .into(),
             AddEdgeAttribute {
@@ -90,6 +97,7 @@ fn can_parse_blocks() {
                     name: precedence,
                     value: Expression::TrueLiteral
                 }],
+                location: Location { row: 7, column: 10 },
             }
             .into(),
             AddGraphNodeAttribute {
@@ -114,6 +122,7 @@ fn can_parse_blocks() {
                         value: Expression::TrueLiteral
                     },
                 ],
+                location: Location { row: 8, column: 10 },
             }
             .into(),
             DeclareMutable {
@@ -129,6 +138,7 @@ fn can_parse_blocks() {
                 }
                 .into(),
                 value: loc1.into(),
+                location: Location { row: 9, column: 10 },
             }
             .into(),
             Assign {
@@ -144,6 +154,10 @@ fn can_parse_blocks() {
                 }
                 .into(),
                 value: loc1.into(),
+                location: Location {
+                    row: 10,
+                    column: 10
+                },
             }
             .into(),
         ]]
@@ -179,16 +193,19 @@ fn can_parse_literals() {
             DeclareImmutable {
                 variable: f.into(),
                 value: Expression::FalseLiteral,
+                location: Location { row: 3, column: 10 },
             }
             .into(),
             DeclareImmutable {
                 variable: n.into(),
                 value: Expression::NullLiteral,
+                location: Location { row: 4, column: 10 },
             }
             .into(),
             DeclareImmutable {
                 variable: t.into(),
                 value: Expression::TrueLiteral,
+                location: Location { row: 5, column: 10 },
             }
             .into(),
         ]]
@@ -219,6 +236,7 @@ fn can_parse_strings() {
         vec![vec![DeclareImmutable {
             variable: loc1.into(),
             value: String::from("\"abc,\ndef\\").into(),
+            location: Location { row: 3, column: 10 },
         }
         .into()]]
     );


### PR DESCRIPTION
Adds the (start) location of statements and stanzas to the AST, so that it can be included in error messages.

Things to note:

- Currently, the location is included in Eq/PartialEq.

- The location is _not_ included in expressions, as I expect the location of the containing statement to be sufficient for debugging.
