### PR TITLE
Remove Context object and DisplayFromFoo traits

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -13,8 +13,6 @@ use tree_sitter::CaptureQuantifier;
 use tree_sitter::Language;
 use tree_sitter::Query;
 
-use crate::Context;
-use crate::DisplayWithContext;
 use crate::Identifier;
 use crate::Location;
 
@@ -73,20 +71,20 @@ pub enum Statement {
     ForIn(ForIn),
 }
 
-impl DisplayWithContext for Statement {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for Statement {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Statement::DeclareImmutable(stmt) => stmt.fmt(f, ctx),
-            Statement::DeclareMutable(stmt) => stmt.fmt(f, ctx),
-            Statement::Assign(stmt) => stmt.fmt(f, ctx),
-            Statement::CreateGraphNode(stmt) => stmt.fmt(f, ctx),
-            Statement::AddGraphNodeAttribute(stmt) => stmt.fmt(f, ctx),
-            Statement::CreateEdge(stmt) => stmt.fmt(f, ctx),
-            Statement::AddEdgeAttribute(stmt) => stmt.fmt(f, ctx),
-            Statement::Scan(stmt) => stmt.fmt(f, ctx),
-            Statement::Print(stmt) => stmt.fmt(f, ctx),
-            Statement::If(stmt) => stmt.fmt(f, ctx),
-            Statement::ForIn(stmt) => stmt.fmt(f, ctx),
+            Self::DeclareImmutable(stmt) => stmt.fmt(f),
+            Self::DeclareMutable(stmt) => stmt.fmt(f),
+            Self::Assign(stmt) => stmt.fmt(f),
+            Self::CreateGraphNode(stmt) => stmt.fmt(f),
+            Self::AddGraphNodeAttribute(stmt) => stmt.fmt(f),
+            Self::CreateEdge(stmt) => stmt.fmt(f),
+            Self::AddEdgeAttribute(stmt) => stmt.fmt(f),
+            Self::Scan(stmt) => stmt.fmt(f),
+            Self::Print(stmt) => stmt.fmt(f),
+            Self::If(stmt) => stmt.fmt(f),
+            Self::ForIn(stmt) => stmt.fmt(f),
         }
     }
 }
@@ -106,16 +104,11 @@ impl From<AddEdgeAttribute> for Statement {
     }
 }
 
-impl DisplayWithContext for AddEdgeAttribute {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(
-            f,
-            "attr ({} -> {})",
-            self.source.display_with(ctx),
-            self.sink.display_with(ctx),
-        )?;
+impl std::fmt::Display for AddEdgeAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "attr ({} -> {})", self.source, self.sink)?;
         for attr in &self.attributes {
-            write!(f, " {}", attr.display_with(ctx))?;
+            write!(f, " {}", attr)?;
         }
         write!(f, " at {}", self.location)
     }
@@ -135,11 +128,11 @@ impl From<AddGraphNodeAttribute> for Statement {
     }
 }
 
-impl DisplayWithContext for AddGraphNodeAttribute {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(f, "attr ({})", self.node.display_with(ctx),)?;
+impl std::fmt::Display for AddGraphNodeAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "attr ({})", self.node)?;
         for attr in &self.attributes {
-            write!(f, " {}", attr.display_with(ctx),)?;
+            write!(f, " {}", attr)?;
         }
         write!(f, " at {}", self.location)
     }
@@ -159,14 +152,12 @@ impl From<Assign> for Statement {
     }
 }
 
-impl DisplayWithContext for Assign {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for Assign {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "set {} = {} at {}",
-            self.variable.display_with(ctx),
-            self.value.display_with(ctx),
-            self.location,
+            self.variable, self.value, self.location,
         )
     }
 }
@@ -178,14 +169,9 @@ pub struct Attribute {
     pub value: Expression,
 }
 
-impl DisplayWithContext for Attribute {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(
-            f,
-            "{} = {}",
-            self.name.display_with(ctx),
-            self.value.display_with(ctx),
-        )
+impl std::fmt::Display for Attribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} = {}", self.name, self.value)
     }
 }
 
@@ -203,14 +189,12 @@ impl From<CreateEdge> for Statement {
     }
 }
 
-impl DisplayWithContext for CreateEdge {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for CreateEdge {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "edge {} -> {} at {}",
-            self.source.display_with(ctx),
-            self.sink.display_with(ctx),
-            self.location,
+            self.source, self.sink, self.location,
         )
     }
 }
@@ -228,14 +212,9 @@ impl From<CreateGraphNode> for Statement {
     }
 }
 
-impl DisplayWithContext for CreateGraphNode {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(
-            f,
-            "node {} at {}",
-            self.node.display_with(ctx),
-            self.location
-        )
+impl std::fmt::Display for CreateGraphNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "node {} at {}", self.node, self.location)
     }
 }
 
@@ -253,14 +232,12 @@ impl From<DeclareImmutable> for Statement {
     }
 }
 
-impl DisplayWithContext for DeclareImmutable {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for DeclareImmutable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "let {} = {} at {}",
-            self.variable.display_with(ctx),
-            self.value.display_with(ctx),
-            self.location,
+            self.variable, self.value, self.location,
         )
     }
 }
@@ -279,14 +256,12 @@ impl From<DeclareMutable> for Statement {
     }
 }
 
-impl DisplayWithContext for DeclareMutable {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for DeclareMutable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "var {} = {} at {}",
-            self.variable.display_with(ctx),
-            self.value.display_with(ctx),
-            self.location,
+            self.variable, self.value, self.location,
         )
     }
 }
@@ -304,11 +279,11 @@ impl From<Print> for Statement {
     }
 }
 
-impl DisplayWithContext for Print {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for Print {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "print")?;
         for val in &self.values {
-            write!(f, " {},", val.display_with(ctx),)?;
+            write!(f, " {},", val)?;
         }
         write!(f, " at {}", self.location)
     }
@@ -328,14 +303,9 @@ impl From<Scan> for Statement {
     }
 }
 
-impl DisplayWithContext for Scan {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(
-            f,
-            "scan {} {{ ... }} at {}",
-            self.value.display_with(ctx),
-            self.location
-        )
+impl std::fmt::Display for Scan {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "scan {} {{ ... }} at {}", self.value, self.location)
     }
 }
 
@@ -355,8 +325,8 @@ impl PartialEq for ScanArm {
     }
 }
 
-impl DisplayWithContext for ScanArm {
-    fn fmt(&self, f: &mut fmt::Formatter, _ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for ScanArm {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?} {{ ... }}", self.regex.as_str())
     }
 }
@@ -374,16 +344,16 @@ impl From<If> for Statement {
     }
 }
 
-impl DisplayWithContext for If {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for If {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         let mut first = true;
         for arm in &self.arms {
             if first {
                 first = false;
-                write!(f, "if {} {{ ... }}", arm.conditions.display_with(ctx))?;
+                write!(f, "if {} {{ ... }}", DisplayConditions(&arm.conditions))?;
             } else {
                 if !arm.conditions.is_empty() {
-                    write!(f, " elif {} {{ ... }}", arm.conditions.display_with(ctx))?;
+                    write!(f, " elif {} {{ ... }}", DisplayConditions(&arm.conditions))?;
                 } else {
                     write!(f, " else {{ ... }}")?;
                 }
@@ -401,6 +371,8 @@ pub struct IfArm {
     pub location: Location,
 }
 
+struct DisplayConditions<'a>(&'a Vec<Condition>);
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum Condition {
     Some {
@@ -417,32 +389,32 @@ pub enum Condition {
     },
 }
 
-impl DisplayWithContext for Vec<Condition> {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for DisplayConditions<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         let mut first = true;
-        for condition in self.iter() {
+        for condition in self.0.iter() {
             if first {
                 first = false;
-                write!(f, "{}", condition.display_with(ctx))?;
+                write!(f, "{}", condition)?;
             } else {
-                write!(f, ", {}", condition.display_with(ctx))?;
+                write!(f, ", {}", condition)?;
             }
         }
         Ok(())
     }
 }
 
-impl DisplayWithContext for Condition {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for Condition {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         match self {
             Condition::Some { value, .. } => {
-                write!(f, "some {}", value.display_with(ctx))
+                write!(f, "some {}", value)
             }
             Condition::None { value, .. } => {
-                write!(f, "none {}", value.display_with(ctx))
+                write!(f, "none {}", value)
             }
             Condition::Bool { value, .. } => {
-                write!(f, "{}", value.display_with(ctx))
+                write!(f, "{}", value)
             }
         }
     }
@@ -463,14 +435,12 @@ impl From<ForIn> for Statement {
     }
 }
 
-impl DisplayWithContext for ForIn {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for ForIn {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "for {} in {} {{ ... }} at {}",
-            self.variable.display_with(ctx),
-            self.value.display_with(ctx),
-            self.location,
+            self.variable, self.value, self.location,
         )
     }
 }
@@ -482,11 +452,11 @@ pub enum Variable {
     Unscoped(UnscopedVariable),
 }
 
-impl DisplayWithContext for Variable {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for Variable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Variable::Scoped(variable) => variable.fmt(f, ctx),
-            Variable::Unscoped(variable) => variable.fmt(f, ctx),
+            Variable::Scoped(variable) => variable.fmt(f),
+            Variable::Unscoped(variable) => variable.fmt(f),
         }
     }
 }
@@ -505,14 +475,9 @@ impl From<ScopedVariable> for Variable {
     }
 }
 
-impl DisplayWithContext for ScopedVariable {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(
-            f,
-            "{}.{}",
-            self.scope.display_with(ctx),
-            self.name.display_with(ctx),
-        )
+impl std::fmt::Display for ScopedVariable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}.{}", self.scope, self.name)
     }
 }
 
@@ -529,9 +494,9 @@ impl From<UnscopedVariable> for Variable {
     }
 }
 
-impl DisplayWithContext for UnscopedVariable {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(f, "{}", self.name.display_with(ctx))
+impl std::fmt::Display for UnscopedVariable {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.name)
     }
 }
 
@@ -558,20 +523,20 @@ pub enum Expression {
     RegexCapture(RegexCapture),
 }
 
-impl DisplayWithContext for Expression {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for Expression {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Expression::FalseLiteral => write!(f, "false"),
             Expression::NullLiteral => write!(f, "#null"),
             Expression::TrueLiteral => write!(f, "true"),
-            Expression::IntegerConstant(expr) => expr.fmt(f, ctx),
-            Expression::StringConstant(expr) => expr.fmt(f, ctx),
-            Expression::List(expr) => expr.fmt(f, ctx),
-            Expression::Set(expr) => expr.fmt(f, ctx),
-            Expression::Capture(expr) => expr.fmt(f, ctx),
-            Expression::Variable(expr) => expr.fmt(f, ctx),
-            Expression::Call(expr) => expr.fmt(f, ctx),
-            Expression::RegexCapture(expr) => expr.fmt(f, ctx),
+            Expression::IntegerConstant(expr) => expr.fmt(f),
+            Expression::StringConstant(expr) => expr.fmt(f),
+            Expression::List(expr) => expr.fmt(f),
+            Expression::Set(expr) => expr.fmt(f),
+            Expression::Capture(expr) => expr.fmt(f),
+            Expression::Variable(expr) => expr.fmt(f),
+            Expression::Call(expr) => expr.fmt(f),
+            Expression::RegexCapture(expr) => expr.fmt(f),
         }
     }
 }
@@ -589,11 +554,11 @@ impl From<Call> for Expression {
     }
 }
 
-impl DisplayWithContext for Call {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(f, "({}", self.function.display_with(ctx))?;
+impl std::fmt::Display for Call {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "({}", self.function)?;
         for arg in &self.parameters {
-            write!(f, " {}", arg.display_with(ctx))?;
+            write!(f, " {}", arg)?;
         }
         write!(f, ")")
     }
@@ -619,9 +584,9 @@ impl From<Capture> for Expression {
     }
 }
 
-impl DisplayWithContext for Capture {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(f, "@{}", self.name.display_with(ctx))
+impl std::fmt::Display for Capture {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "@{}", self.name)
     }
 }
 
@@ -637,8 +602,8 @@ impl From<IntegerConstant> for Expression {
     }
 }
 
-impl DisplayWithContext for IntegerConstant {
-    fn fmt(&self, f: &mut fmt::Formatter, _ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for IntegerConstant {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.value)
     }
 }
@@ -655,16 +620,16 @@ impl From<ListComprehension> for Expression {
     }
 }
 
-impl DisplayWithContext for ListComprehension {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for ListComprehension {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "[")?;
         let mut first = true;
         for elem in &self.elements {
             if first {
-                write!(f, "{}", elem.display_with(ctx))?;
+                write!(f, "{}", elem)?;
                 first = false;
             } else {
-                write!(f, ", {}", elem.display_with(ctx))?;
+                write!(f, ", {}", elem)?;
             }
         }
         write!(f, "]")
@@ -683,8 +648,8 @@ impl From<RegexCapture> for Expression {
     }
 }
 
-impl DisplayWithContext for RegexCapture {
-    fn fmt(&self, f: &mut fmt::Formatter, _ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for RegexCapture {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "${}", self.match_index)
     }
 }
@@ -701,16 +666,16 @@ impl From<SetComprehension> for Expression {
     }
 }
 
-impl DisplayWithContext for SetComprehension {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for SetComprehension {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{{")?;
         let mut first = true;
         for elem in &self.elements {
             if first {
-                write!(f, "{}", elem.display_with(ctx))?;
+                write!(f, "{}", elem)?;
                 first = false;
             } else {
-                write!(f, ", {}", elem.display_with(ctx))?;
+                write!(f, ", {}", elem)?;
             }
         }
         write!(f, "}}")
@@ -729,8 +694,8 @@ impl From<StringConstant> for Expression {
     }
 }
 
-impl DisplayWithContext for StringConstant {
-    fn fmt(&self, f: &mut fmt::Formatter, _ctx: &Context) -> fmt::Result {
+impl std::fmt::Display for StringConstant {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}", self.value)
     }
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -42,11 +42,10 @@ pub trait Function {
 /// # use tree_sitter_graph::graph::Value;
 /// # use tree_sitter_graph::ExecutionError;
 /// # fn main() -> Result<(), ExecutionError> {
-/// # let graph = Graph::new();
 /// # let param_vec = vec![Value::String("test".to_string()), Value::Integer(42)];
 /// # let mut params = param_vec.into_iter();
-/// let first_param = params.param()?.into_string(&graph)?;
-/// let second_param = params.param()?.into_integer(&graph)?;
+/// let first_param = params.param()?.into_string()?;
+/// let second_param = params.param()?.into_integer()?;
 /// // etc
 /// params.finish()?;
 /// # Ok(())
@@ -212,7 +211,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 let parent = match node.parent() {
                     Some(parent) => parent,
@@ -240,7 +239,7 @@ pub mod stdlib {
                 source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 Ok(Value::String(source[node.byte_range()].to_string()))
             }
@@ -257,7 +256,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.start_position().row as u32))
             }
@@ -275,7 +274,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.start_position().column as u32))
             }
@@ -292,7 +291,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.end_position().row as u32))
             }
@@ -309,7 +308,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.end_position().column as u32))
             }
@@ -326,7 +325,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 Ok(Value::String(node.kind().to_string()))
             }
@@ -344,7 +343,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
+                let node = graph[parameters.param()?.into_syntax_node_ref()?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.named_child_count() as u32))
             }
@@ -380,11 +379,11 @@ pub mod stdlib {
         impl Function for Not {
             fn call(
                 &mut self,
-                graph: &mut Graph,
+                _graph: &mut Graph,
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let result = !parameters.param()?.into_bool(graph)?;
+                let result = !parameters.param()?.into_bool()?;
                 parameters.finish()?;
                 Ok(result.into())
             }
@@ -396,13 +395,13 @@ pub mod stdlib {
         impl Function for And {
             fn call(
                 &mut self,
-                graph: &mut Graph,
+                _graph: &mut Graph,
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
                 let mut result = true;
                 while let Ok(parameter) = parameters.param() {
-                    result &= parameter.into_bool(graph)?;
+                    result &= parameter.into_bool()?;
                 }
                 Ok(result.into())
             }
@@ -414,13 +413,13 @@ pub mod stdlib {
         impl Function for Or {
             fn call(
                 &mut self,
-                graph: &mut Graph,
+                _graph: &mut Graph,
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
                 let mut result = false;
                 while let Ok(parameter) = parameters.param() {
-                    result |= parameter.into_bool(graph)?;
+                    result |= parameter.into_bool()?;
                 }
                 Ok(result.into())
             }
@@ -436,13 +435,13 @@ pub mod stdlib {
         impl Function for Plus {
             fn call(
                 &mut self,
-                graph: &mut Graph,
+                _graph: &mut Graph,
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
                 let mut result = 0;
                 while let Ok(parameter) = parameters.param() {
-                    result += parameter.into_integer(graph)?;
+                    result += parameter.into_integer()?;
                 }
                 Ok(Value::Integer(result))
             }
@@ -458,14 +457,14 @@ pub mod stdlib {
         impl Function for Replace {
             fn call(
                 &mut self,
-                graph: &mut Graph,
+                _graph: &mut Graph,
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let text = parameters.param()?.into_string(graph)?;
-                let pattern = parameters.param()?.into_string(graph)?;
+                let text = parameters.param()?.into_string()?;
+                let pattern = parameters.param()?.into_string()?;
                 let pattern = Regex::new(&pattern).map_err(ExecutionError::other)?;
-                let replacement = parameters.param()?.into_string(graph)?;
+                let replacement = parameters.param()?.into_string()?;
                 parameters.finish()?;
                 Ok(Value::String(
                     pattern.replace_all(&text, replacement).to_string(),

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -43,7 +43,7 @@ pub trait Function {
 /// # let param_vec = vec![Value::String("test".to_string()), Value::Integer(42)];
 /// # let mut params = param_vec.into_iter();
 /// let first_param = params.param()?.into_string()?;
-/// let second_param = params.param()?.into_integer()?;
+/// let second_param = params.param()?.as_integer()?;
 /// // etc
 /// params.finish()?;
 /// # Ok(())
@@ -374,7 +374,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let result = !parameters.param()?.into_bool()?;
+                let result = !parameters.param()?.as_boolean()?;
                 parameters.finish()?;
                 Ok(result.into())
             }
@@ -392,7 +392,7 @@ pub mod stdlib {
             ) -> Result<Value, ExecutionError> {
                 let mut result = true;
                 while let Ok(parameter) = parameters.param() {
-                    result &= parameter.into_bool()?;
+                    result &= parameter.as_boolean()?;
                 }
                 Ok(result.into())
             }
@@ -410,7 +410,7 @@ pub mod stdlib {
             ) -> Result<Value, ExecutionError> {
                 let mut result = false;
                 while let Ok(parameter) = parameters.param() {
-                    result |= parameter.into_bool()?;
+                    result |= parameter.as_boolean()?;
                 }
                 Ok(result.into())
             }
@@ -432,7 +432,7 @@ pub mod stdlib {
             ) -> Result<Value, ExecutionError> {
                 let mut result = 0;
                 while let Ok(parameter) = parameters.param() {
-                    result += parameter.into_integer()?;
+                    result += parameter.as_integer()?;
                 }
                 Ok(Value::Integer(result))
             }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -12,8 +12,6 @@ use std::collections::HashMap;
 use crate::execution::ExecutionError;
 use crate::graph::Graph;
 use crate::graph::Value;
-use crate::Context;
-use crate::DisplayWithContext;
 use crate::Identifier;
 
 /// The implementation of a function that can be called from the graph DSL.
@@ -98,41 +96,38 @@ impl Functions {
 
     /// Returns the standard library of functions, as defined in the [language
     /// reference][`crate::reference::functions`].
-    pub fn stdlib(ctx: &mut Context) -> Functions {
+    pub fn stdlib() -> Functions {
         let mut functions = Functions::new();
         // general functions
-        functions.add(ctx.add_identifier("is-null"), stdlib::IsNull);
+        functions.add(Identifier::from("is-null"), stdlib::IsNull);
         // tree functions
         functions.add(
-            ctx.add_identifier("named-child-index"),
+            Identifier::from("named-child-index"),
             stdlib::syntax::NamedChildIndex,
         );
+        functions.add(Identifier::from("source-text"), stdlib::syntax::SourceText);
+        functions.add(Identifier::from("start-row"), stdlib::syntax::StartRow);
         functions.add(
-            ctx.add_identifier("source-text"),
-            stdlib::syntax::SourceText,
-        );
-        functions.add(ctx.add_identifier("start-row"), stdlib::syntax::StartRow);
-        functions.add(
-            ctx.add_identifier("start-column"),
+            Identifier::from("start-column"),
             stdlib::syntax::StartColumn,
         );
-        functions.add(ctx.add_identifier("end-row"), stdlib::syntax::EndRow);
-        functions.add(ctx.add_identifier("end-column"), stdlib::syntax::EndColumn);
-        functions.add(ctx.add_identifier("node-type"), stdlib::syntax::NodeType);
+        functions.add(Identifier::from("end-row"), stdlib::syntax::EndRow);
+        functions.add(Identifier::from("end-column"), stdlib::syntax::EndColumn);
+        functions.add(Identifier::from("node-type"), stdlib::syntax::NodeType);
         functions.add(
-            ctx.add_identifier("named-child-count"),
+            Identifier::from("named-child-count"),
             stdlib::syntax::NamedChildCount,
         );
         // graph functions
-        functions.add(ctx.add_identifier("node"), stdlib::graph::Node);
+        functions.add(Identifier::from("node"), stdlib::graph::Node);
         // boolean functions
-        functions.add(ctx.add_identifier("not"), stdlib::bool::Not);
-        functions.add(ctx.add_identifier("and"), stdlib::bool::And);
-        functions.add(ctx.add_identifier("or"), stdlib::bool::Or);
+        functions.add(Identifier::from("not"), stdlib::bool::Not);
+        functions.add(Identifier::from("and"), stdlib::bool::And);
+        functions.add(Identifier::from("or"), stdlib::bool::Or);
         // math functions
-        functions.add(ctx.add_identifier("plus"), stdlib::math::Plus);
+        functions.add(Identifier::from("plus"), stdlib::math::Plus);
         // string functions
-        functions.add(ctx.add_identifier("replace"), stdlib::string::Replace);
+        functions.add(Identifier::from("replace"), stdlib::string::Replace);
         functions
     }
 
@@ -147,19 +142,15 @@ impl Functions {
     /// Calls a named function, returning an error if there is no function with that name.
     pub fn call(
         &mut self,
-        ctx: &Context,
-        name: Identifier,
+        name: &Identifier,
         graph: &mut Graph,
         source: &str,
         parameters: &mut dyn Parameters,
     ) -> Result<Value, ExecutionError> {
         let function = self
             .functions
-            .get_mut(&name)
-            .ok_or(ExecutionError::UndefinedFunction(format!(
-                "{}",
-                name.display_with(ctx)
-            )))?;
+            .get_mut(name)
+            .ok_or(ExecutionError::UndefinedFunction(format!("{}", name)))?;
         function.call(graph, source, parameters)
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,10 +7,12 @@
 
 //! Defines data types for the graphs produced by the graph DSL
 
+use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::fmt;
+use std::hash::Hash;
 use std::ops::Index;
 use std::ops::IndexMut;
 
@@ -279,8 +281,12 @@ impl Attributes {
     }
 
     /// Returns the value of a particular attribute, if it exists.
-    pub fn get(&self, name: Identifier) -> Option<&Value> {
-        self.values.get(&name)
+    pub fn get<Q>(&self, name: &Q) -> Option<&Value>
+    where
+        Q: ?Sized + Eq + Hash,
+        Identifier: Borrow<Q>,
+    {
+        self.values.get(name.borrow())
     }
 }
 
@@ -289,7 +295,7 @@ impl std::fmt::Display for Attributes {
         let mut keys = self.values.keys().collect::<Vec<_>>();
         keys.sort_by(|a, b| a.cmp(b));
         for key in &keys {
-            let value = &self.values[key];
+            let value = &self.values[*key];
             write!(f, "  {}: {}\n", key, value)?;
         }
         Ok(())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -324,21 +324,22 @@ pub enum Value {
 
 impl Value {
     /// Check if this value is null
-    pub fn is_null(self) -> bool {
+    pub fn is_null(&self) -> bool {
         match self {
             Value::Null => true,
             _ => false,
         }
     }
+
     /// Coerces this value into a boolean, returning an error if it's some other type of value.
-    pub fn into_bool(self) -> Result<bool, ExecutionError> {
+    pub fn into_boolean(self) -> Result<bool, ExecutionError> {
         match self {
             Value::Boolean(value) => Ok(value),
             _ => Err(ExecutionError::ExpectedBoolean(format!("got {}", self))),
         }
     }
 
-    pub fn as_bool(&self) -> Result<bool, ExecutionError> {
+    pub fn as_boolean(&self) -> Result<bool, ExecutionError> {
         match self {
             Value::Boolean(value) => Ok(*value),
             _ => Err(ExecutionError::ExpectedBoolean(format!("got {}", self))),
@@ -368,7 +369,7 @@ impl Value {
         }
     }
 
-    pub fn as_string(&self) -> Result<&str, ExecutionError> {
+    pub fn as_str(&self) -> Result<&str, ExecutionError> {
         match self {
             Value::String(value) => Ok(value),
             _ => Err(ExecutionError::ExpectedString(format!("got {}", self))),
@@ -554,6 +555,13 @@ impl std::fmt::Display for SyntaxNodeRef {
 /// A reference to a graph node
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct GraphNodeRef(GraphNodeID);
+
+impl GraphNodeRef {
+    /// Returns the index of the graph node that this reference refers to.
+    pub fn index(self) -> usize {
+        self.0 as usize
+    }
+}
 
 impl From<GraphNodeRef> for Value {
     fn from(value: GraphNodeRef) -> Value {

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -25,7 +25,6 @@ use crate::execution::query_capture_value;
 use crate::execution::ExecutionError;
 use crate::functions::Functions;
 use crate::graph;
-use crate::graph::DisplayWithGraph as _;
 use crate::graph::Graph;
 use crate::variables::Globals;
 use crate::variables::VariableMap;
@@ -189,11 +188,7 @@ impl ast::Stanza {
             prev_element_debug_info,
         };
         let node = query_capture_value(self.full_match_file_capture_index, One, &mat, exec.graph);
-        debug!(
-            "match {} at {}",
-            node.display_with(exec.graph),
-            self.location
-        );
+        debug!("match {} at {}", node, self.location);
         trace!("{{");
         for statement in &self.statements {
             statement
@@ -290,7 +285,7 @@ impl ast::AddEdgeAttribute {
 
 impl ast::Scan {
     fn execute_lazy(&self, exec: &mut ExecutionContext) -> Result<(), ExecutionError> {
-        let match_string = self.value.evaluate_eager(exec)?.into_string(exec.graph)?;
+        let match_string = self.value.evaluate_eager(exec)?.into_string()?;
 
         let mut i = 0;
         let mut matches = Vec::new();
@@ -421,14 +416,14 @@ impl ast::Condition {
         match self {
             Self::Some { value, .. } => Ok(!value.evaluate_eager(exec)?.is_null()),
             Self::None { value, .. } => Ok(value.evaluate_eager(exec)?.is_null()),
-            Self::Bool { value, .. } => Ok(value.evaluate_eager(exec)?.into_bool(exec.graph)?),
+            Self::Bool { value, .. } => Ok(value.evaluate_eager(exec)?.into_bool()?),
         }
     }
 }
 
 impl ast::ForIn {
     fn execute_lazy(&self, exec: &mut ExecutionContext) -> Result<(), ExecutionError> {
-        let values = self.value.evaluate_eager(exec)?.into_list(exec.graph)?;
+        let values = self.value.evaluate_eager(exec)?.into_list()?;
         let mut loop_locals = VariableMap::new_child(exec.locals);
         for value in values {
             loop_locals.clear();

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -13,7 +13,6 @@ use anyhow::Context as _;
 use log::{debug, trace};
 
 use std::collections::HashMap;
-use std::fmt;
 
 use tree_sitter::CaptureQuantifier::One;
 use tree_sitter::QueryCursor;
@@ -29,8 +28,6 @@ use crate::graph::Graph;
 use crate::variables::Globals;
 use crate::variables::VariableMap;
 use crate::variables::Variables;
-use crate::Context;
-use crate::DisplayWithContext as _;
 use crate::Identifier;
 
 use statements::*;
@@ -43,14 +40,13 @@ impl ast::File {
     /// provide the set of functions and global variables that are available during execution.
     pub fn execute_lazy<'tree>(
         &self,
-        ctx: &Context,
         tree: &'tree Tree,
         source: &'tree str,
         functions: &mut Functions,
         globals: &Globals,
     ) -> Result<Graph<'tree>, ExecutionError> {
         let mut graph = Graph::new();
-        self.execute_lazy_into(ctx, &mut graph, tree, source, functions, globals)?;
+        self.execute_lazy_into(&mut graph, tree, source, functions, globals)?;
         Ok(graph)
     }
 
@@ -61,7 +57,6 @@ impl ast::File {
     /// “pre-seed” the graph with some predefined nodes and/or edges before executing the DSL file.
     pub fn execute_lazy_into<'tree>(
         &self,
-        ctx: &Context,
         graph: &mut Graph<'tree>,
         tree: &'tree Tree,
         source: &'tree str,
@@ -84,7 +79,6 @@ impl ast::File {
         for mat in matches {
             let stanza = &self.stanzas[mat.pattern_index];
             stanza.execute_lazy(
-                ctx,
                 source,
                 &mat,
                 graph,
@@ -102,7 +96,6 @@ impl ast::File {
         for graph_stmt in &lazy_graph {
             graph_stmt
                 .evaluate(&mut EvaluationContext {
-                    ctx,
                     source,
                     graph,
                     functions,
@@ -111,7 +104,7 @@ impl ast::File {
                     function_parameters: &mut function_parameters,
                     prev_element_debug_info: &mut prev_element_debug_info,
                 })
-                .with_context(|| format!("Executing {}", graph_stmt.display_with(ctx, &graph)))?;
+                .with_context(|| format!("Executing {}", graph_stmt))?;
         }
 
         Ok(())
@@ -120,7 +113,6 @@ impl ast::File {
 
 /// Context for execution, which executes stanzas to build the lazy graph
 struct ExecutionContext<'a, 'g, 'tree> {
-    ctx: &'a Context,
     source: &'tree str,
     graph: &'a mut Graph<'tree>,
     functions: &'a mut Functions,
@@ -137,7 +129,6 @@ struct ExecutionContext<'a, 'g, 'tree> {
 
 /// Context for evaluation, which evalautes the lazy graph to build the actual graph
 pub(self) struct EvaluationContext<'a, 'tree> {
-    pub ctx: &'a Context,
     pub source: &'tree str,
     pub graph: &'a mut Graph<'tree>,
     pub functions: &'a mut Functions,
@@ -157,7 +148,6 @@ pub(super) enum GraphElementKey {
 impl ast::Stanza {
     fn execute_lazy<'l, 'g, 'q, 'tree>(
         &self,
-        ctx: &Context,
         source: &'tree str,
         mat: &QueryMatch<'_, 'tree>,
         graph: &mut Graph<'tree>,
@@ -173,7 +163,6 @@ impl ast::Stanza {
         let current_regex_captures = vec![];
         locals.clear();
         let mut exec = ExecutionContext {
-            ctx,
             source,
             graph,
             functions,
@@ -193,7 +182,7 @@ impl ast::Stanza {
         for statement in &self.statements {
             statement
                 .execute_lazy(&mut exec)
-                .with_context(|| format!("Executing {}", statement.display_with(exec.ctx)))?;
+                .with_context(|| format!("Executing {}", statement))?;
         }
         trace!("}}");
         Ok(())
@@ -324,7 +313,6 @@ impl ast::Scan {
 
             let mut arm_locals = VariableMap::new_child(exec.locals);
             let mut arm_exec = ExecutionContext {
-                ctx: exec.ctx,
                 source: exec.source,
                 graph: exec.graph,
                 functions: exec.functions,
@@ -342,7 +330,7 @@ impl ast::Scan {
             for statement in &arm.statements {
                 statement
                     .execute_lazy(&mut arm_exec)
-                    .with_context(|| format!("Executing {}", statement.display_with(arm_exec.ctx)))
+                    .with_context(|| format!("Executing {}", statement))
                     .with_context(|| {
                         format!(
                             "Matching {} with arm \"{}\" {{ ... }}",
@@ -385,7 +373,6 @@ impl ast::If {
             if result {
                 let mut arm_locals = VariableMap::new_child(exec.locals);
                 let mut arm_exec = ExecutionContext {
-                    ctx: exec.ctx,
                     source: exec.source,
                     graph: exec.graph,
                     functions: exec.functions,
@@ -428,7 +415,6 @@ impl ast::ForIn {
         for value in values {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
-                ctx: exec.ctx,
                 source: exec.source,
                 graph: exec.graph,
                 functions: exec.functions,
@@ -473,7 +459,6 @@ impl ast::Expression {
     // only be called on expressions that are local (i.e., `is_local = true` in the checker).
     fn evaluate_eager(&self, exec: &mut ExecutionContext) -> Result<graph::Value, ExecutionError> {
         self.evaluate_lazy(exec)?.evaluate(&mut EvaluationContext {
-            ctx: exec.ctx,
             source: exec.source,
             graph: exec.graph,
             functions: exec.functions,
@@ -535,7 +520,7 @@ impl ast::Call {
         for parameter in &self.parameters {
             parameters.push(parameter.evaluate_lazy(exec)?);
         }
-        Ok(LazyCall::new(self.function, parameters).into())
+        Ok(LazyCall::new(self.function.clone(), parameters).into())
     }
 }
 
@@ -583,7 +568,7 @@ impl ast::Variable {
 impl ast::ScopedVariable {
     fn evaluate_lazy(&self, exec: &mut ExecutionContext) -> Result<LazyValue, ExecutionError> {
         let scope = self.scope.evaluate_lazy(exec)?;
-        let value = LazyScopedVariable::new(scope, self.name);
+        let value = LazyScopedVariable::new(scope, self.name.clone());
         Ok(value.into())
     }
 
@@ -596,30 +581,27 @@ impl ast::ScopedVariable {
         if mutable {
             return Err(ExecutionError::CannotDefineMutableScopedVariable(format!(
                 "{}",
-                self.display_with(exec.ctx)
+                self
             )));
         }
         let scope = self.scope.evaluate_lazy(exec)?;
-        let variable = exec
-            .store
-            .add(value, self.location.into(), exec.ctx, exec.graph);
+        let variable = exec.store.add(value, self.location.into());
         exec.scoped_store.add(
             scope,
-            self.name,
+            self.name.clone(),
             variable.into(),
             self.location.into(),
-            exec.ctx,
         )
     }
 
     fn set_lazy(
         &self,
-        exec: &mut ExecutionContext,
+        _exec: &mut ExecutionContext,
         _value: LazyValue,
     ) -> Result<(), ExecutionError> {
         Err(ExecutionError::CannotAssignScopedVariable(format!(
             "{}",
-            self.display_with(exec.ctx)
+            self
         )))
     }
 }
@@ -631,9 +613,7 @@ impl ast::UnscopedVariable {
         } else {
             exec.locals.get(&self.name).map(|value| value.clone())
         }
-        .ok_or_else(|| {
-            ExecutionError::UndefinedVariable(format!("{}", self.display_with(exec.ctx)))
-        })
+        .ok_or_else(|| ExecutionError::UndefinedVariable(format!("{}", self)))
     }
 }
 
@@ -647,17 +627,13 @@ impl ast::UnscopedVariable {
         if exec.globals.get(&self.name).is_some() {
             return Err(ExecutionError::DuplicateVariable(format!(
                 " global {}",
-                self.display_with(exec.ctx)
+                self
             )));
         }
-        let value = exec
-            .store
-            .add(value, self.location.into(), exec.ctx, exec.graph);
+        let value = exec.store.add(value, self.location.into());
         exec.locals
-            .add(self.name, value.into(), mutable)
-            .map_err(|_| {
-                ExecutionError::DuplicateVariable(format!(" local {}", self.display_with(exec.ctx)))
-            })
+            .add(self.name.clone(), value.into(), mutable)
+            .map_err(|_| ExecutionError::DuplicateVariable(format!(" local {}", self)))
     }
 
     fn set_lazy(
@@ -668,69 +644,26 @@ impl ast::UnscopedVariable {
         if exec.globals.get(&self.name).is_some() {
             return Err(ExecutionError::CannotAssignImmutableVariable(format!(
                 " global {}",
-                self.display_with(exec.ctx)
+                self
             )));
         }
-        let value = exec
-            .store
-            .add(value, self.location.into(), exec.ctx, exec.graph);
-        exec.locals.set(self.name, value.into()).map_err(|_| {
-            if exec.locals.get(&self.name).is_some() {
-                ExecutionError::CannotAssignImmutableVariable(format!(
-                    "{}",
-                    self.display_with(exec.ctx)
-                ))
-            } else {
-                ExecutionError::UndefinedVariable(format!("{}", self.display_with(exec.ctx)))
-            }
-        })
+        let value = exec.store.add(value, self.location.into());
+        exec.locals
+            .set(self.name.clone(), value.into())
+            .map_err(|_| {
+                if exec.locals.get(&self.name).is_some() {
+                    ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
+                } else {
+                    ExecutionError::UndefinedVariable(format!("{}", self))
+                }
+            })
     }
 }
 
 impl ast::Attribute {
     fn evaluate_lazy(&self, exec: &mut ExecutionContext) -> Result<LazyAttribute, ExecutionError> {
         let value = self.value.evaluate_lazy(exec)?;
-        let attribute = LazyAttribute::new(self.name, value);
+        let attribute = LazyAttribute::new(self.name.clone(), value);
         Ok(attribute)
-    }
-}
-
-/// Trait to Display with a given Context and Graph
-pub trait DisplayWithContextAndGraph
-where
-    Self: Sized,
-{
-    fn fmt<'tree>(
-        &self,
-        f: &mut fmt::Formatter,
-        ctx: &Context,
-        graph: &Graph<'tree>,
-    ) -> fmt::Result;
-
-    fn display_with<'a, 'tree>(
-        &'a self,
-        ctx: &'a Context,
-        graph: &'a Graph<'tree>,
-    ) -> Box<dyn fmt::Display + 'a> {
-        struct Impl<'a, 'tree, T: DisplayWithContextAndGraph>(&'a T, &'a Context, &'a Graph<'tree>);
-
-        impl<'a, 'tree, T: DisplayWithContextAndGraph> fmt::Display for Impl<'a, 'tree, T> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                self.0.fmt(f, self.1, self.2)
-            }
-        }
-
-        Box::new(Impl(self, ctx, graph))
-    }
-}
-
-impl<T: DisplayWithContextAndGraph> DisplayWithContextAndGraph for Box<T> {
-    fn fmt<'tree>(
-        &self,
-        f: &mut fmt::Formatter,
-        ctx: &Context,
-        graph: &Graph<'tree>,
-    ) -> fmt::Result {
-        self.as_ref().fmt(f, ctx, graph)
     }
 }

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -403,7 +403,7 @@ impl ast::Condition {
         match self {
             Self::Some { value, .. } => Ok(!value.evaluate_eager(exec)?.is_null()),
             Self::None { value, .. } => Ok(value.evaluate_eager(exec)?.is_null()),
-            Self::Bool { value, .. } => Ok(value.evaluate_eager(exec)?.into_bool()?),
+            Self::Bool { value, .. } => Ok(value.evaluate_eager(exec)?.into_boolean()?),
         }
     }
 }

--- a/src/lazy_execution/statements.rs
+++ b/src/lazy_execution/statements.rs
@@ -13,7 +13,6 @@ use std::convert::From;
 use std::fmt;
 
 use crate::execution::ExecutionError;
-use crate::graph::DisplayWithGraph;
 use crate::graph::Graph;
 use crate::Context;
 use crate::DisplayWithContext as _;
@@ -120,7 +119,7 @@ impl LazyAddGraphNodeAttribute {
                     ExecutionError::DuplicateAttribute(format!(
                         "{} on {} at {} and {}",
                         attribute.name.display_with(exec.ctx),
-                        node.display_with(exec.graph),
+                        node,
                         prev_debug_info.unwrap(),
                         self.debug_info,
                     ))
@@ -166,8 +165,8 @@ impl LazyCreateEdge {
         if let Err(_) = exec.graph[source].add_edge(sink) {
             Err(ExecutionError::DuplicateEdge(format!(
                 "({} -> {}) at {} and {}",
-                source.display_with(exec.graph),
-                sink.display_with(exec.graph),
+                source,
+                sink,
                 prev_debug_info.unwrap(),
                 self.debug_info,
             )))?;
@@ -221,9 +220,7 @@ impl LazyAddEdgeAttribute {
                 Some(edge) => Ok(edge),
                 None => Err(ExecutionError::UndefinedEdge(format!(
                     "({} -> {}) at {}",
-                    source.display_with(exec.graph),
-                    sink.display_with(exec.graph),
-                    self.debug_info,
+                    source, sink, self.debug_info,
                 ))),
             }?;
             let prev_debug_info = exec.prev_element_debug_info.insert(
@@ -234,8 +231,8 @@ impl LazyAddEdgeAttribute {
                 ExecutionError::DuplicateAttribute(format!(
                     "{} on edge ({} -> {}) at {} and {}",
                     attribute.name.display_with(exec.ctx),
-                    source.display_with(exec.graph),
-                    sink.display_with(exec.graph),
+                    source,
+                    sink,
                     prev_debug_info.unwrap(),
                     self.debug_info,
                 ))
@@ -287,7 +284,7 @@ impl LazyPrint {
                 LazyPrintArgument::Text(string) => eprint!("{}", string),
                 LazyPrintArgument::Value(value) => {
                     let value = value.evaluate(exec)?;
-                    eprint!("{}", value.display_with(exec.graph));
+                    eprint!("{}", value);
                 }
             }
         }

--- a/src/lazy_execution/statements.rs
+++ b/src/lazy_execution/statements.rs
@@ -13,14 +13,10 @@ use std::convert::From;
 use std::fmt;
 
 use crate::execution::ExecutionError;
-use crate::graph::Graph;
-use crate::Context;
-use crate::DisplayWithContext as _;
 use crate::Identifier;
 
 use super::store::DebugInfo;
 use super::values::*;
-use super::DisplayWithContextAndGraph;
 use super::EvaluationContext;
 use super::GraphElementKey;
 
@@ -35,7 +31,7 @@ pub(super) enum LazyStatement {
 
 impl LazyStatement {
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
-        debug!("eval {}", self.display_with(exec.ctx, exec.graph));
+        debug!("eval {}", self);
         trace!("{{");
         let result = match self {
             Self::AddGraphNodeAttribute(stmt) => stmt.evaluate(exec),
@@ -72,13 +68,13 @@ impl From<LazyPrint> for LazyStatement {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyStatement {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+impl fmt::Display for LazyStatement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::AddGraphNodeAttribute(stmt) => stmt.fmt(f, ctx, graph),
-            Self::CreateEdge(stmt) => stmt.fmt(f, ctx, graph),
-            Self::AddEdgeAttribute(stmt) => stmt.fmt(f, ctx, graph),
-            Self::Print(stmt) => stmt.fmt(f, ctx, graph),
+            Self::AddGraphNodeAttribute(stmt) => stmt.fmt(f),
+            Self::CreateEdge(stmt) => stmt.fmt(f),
+            Self::AddEdgeAttribute(stmt) => stmt.fmt(f),
+            Self::Print(stmt) => stmt.fmt(f),
         }
     }
 }
@@ -109,16 +105,16 @@ impl LazyAddGraphNodeAttribute {
         for attribute in &self.attributes {
             let value = attribute.value.evaluate(exec)?;
             let prev_debug_info = exec.prev_element_debug_info.insert(
-                GraphElementKey::NodeAttribute(node, attribute.name),
+                GraphElementKey::NodeAttribute(node, attribute.name.clone()),
                 self.debug_info,
             );
             exec.graph[node]
                 .attributes
-                .add(attribute.name, value)
+                .add(attribute.name.clone(), value)
                 .map_err(|_| {
                     ExecutionError::DuplicateAttribute(format!(
                         "{} on {} at {} and {}",
-                        attribute.name.display_with(exec.ctx),
+                        attribute.name,
                         node,
                         prev_debug_info.unwrap(),
                         self.debug_info,
@@ -129,11 +125,11 @@ impl LazyAddGraphNodeAttribute {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyAddGraphNodeAttribute {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
-        write!(f, "attr ({})", self.node.display_with(ctx, graph))?;
+impl fmt::Display for LazyAddGraphNodeAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "attr ({})", self.node)?;
         for attr in &self.attributes {
-            write!(f, " {}", attr.display_with(ctx, graph))?;
+            write!(f, " {}", attr)?;
         }
         write!(f, " at {}", self.debug_info)
     }
@@ -175,14 +171,12 @@ impl LazyCreateEdge {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyCreateEdge {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+impl fmt::Display for LazyCreateEdge {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "edge {} -> {} at {}",
-            self.source.display_with(ctx, graph),
-            self.sink.display_with(ctx, graph),
-            self.debug_info,
+            self.source, self.sink, self.debug_info,
         )
     }
 }
@@ -224,34 +218,31 @@ impl LazyAddEdgeAttribute {
                 ))),
             }?;
             let prev_debug_info = exec.prev_element_debug_info.insert(
-                GraphElementKey::EdgeAttribute(source, sink, attribute.name),
+                GraphElementKey::EdgeAttribute(source, sink, attribute.name.clone()),
                 self.debug_info,
             );
-            edge.attributes.add(attribute.name, value).map_err(|_| {
-                ExecutionError::DuplicateAttribute(format!(
-                    "{} on edge ({} -> {}) at {} and {}",
-                    attribute.name.display_with(exec.ctx),
-                    source,
-                    sink,
-                    prev_debug_info.unwrap(),
-                    self.debug_info,
-                ))
-            })?;
+            edge.attributes
+                .add(attribute.name.clone(), value)
+                .map_err(|_| {
+                    ExecutionError::DuplicateAttribute(format!(
+                        "{} on edge ({} -> {}) at {} and {}",
+                        attribute.name,
+                        source,
+                        sink,
+                        prev_debug_info.unwrap(),
+                        self.debug_info,
+                    ))
+                })?;
         }
         Ok(())
     }
 }
 
-impl DisplayWithContextAndGraph for LazyAddEdgeAttribute {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
-        write!(
-            f,
-            "attr ({} -> {})",
-            self.source.display_with(ctx, graph),
-            self.sink.display_with(ctx, graph),
-        )?;
+impl fmt::Display for LazyAddEdgeAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "attr ({} -> {})", self.source, self.sink,)?;
         for attr in &self.attributes {
-            write!(f, " {}", attr.display_with(ctx, graph),)?;
+            write!(f, " {}", attr,)?;
         }
         write!(f, " at {}", self.debug_info)
     }
@@ -293,8 +284,8 @@ impl LazyPrint {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyPrint {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+impl fmt::Display for LazyPrint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "print")?;
         let mut first = true;
         for argument in &self.arguments {
@@ -305,7 +296,7 @@ impl DisplayWithContextAndGraph for LazyPrint {
             }
             match argument {
                 LazyPrintArgument::Text(string) => write!(f, "\"{}\"", string)?,
-                LazyPrintArgument::Value(value) => write!(f, "{}", value.display_with(ctx, graph))?,
+                LazyPrintArgument::Value(value) => write!(f, "{}", value)?,
             };
         }
         write!(f, " at {}", self.debug_info)
@@ -325,13 +316,8 @@ impl LazyAttribute {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyAttribute {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
-        write!(
-            f,
-            "{} = {}",
-            self.name.display_with(ctx),
-            self.value.display_with(ctx, graph),
-        )
+impl fmt::Display for LazyAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} = {}", self.name, self.value,)
     }
 }

--- a/src/lazy_execution/store.rs
+++ b/src/lazy_execution/store.rs
@@ -134,7 +134,7 @@ impl LazyScopedVariables {
         name: &Identifier,
         exec: &mut EvaluationContext,
     ) -> Result<LazyValue, ExecutionError> {
-        let values = match self.variables.get(&name) {
+        let values = match self.variables.get(name) {
             Some(v) => v,
             None => {
                 return Err(ExecutionError::UndefinedScopedVariable(format!(

--- a/src/lazy_execution/values.rs
+++ b/src/lazy_execution/values.rs
@@ -13,16 +13,12 @@ use std::convert::From;
 use std::fmt;
 
 use crate::execution::ExecutionError;
-use crate::graph::Graph;
 use crate::graph::GraphNodeRef;
 use crate::graph::SyntaxNodeRef;
 use crate::graph::Value;
-use crate::Context;
-use crate::DisplayWithContext;
 use crate::Identifier;
 
 use super::store::*;
-use super::DisplayWithContextAndGraph;
 use super::EvaluationContext;
 
 /// Lazy values
@@ -122,7 +118,7 @@ impl From<LazyCall> for LazyValue {
 
 impl LazyValue {
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<Value, ExecutionError> {
-        trace!("eval {} {{", self.display_with(exec.ctx, exec.graph));
+        trace!("eval {} {{", self);
         let ret = match self {
             Self::Value(value) => Ok(value.clone()),
             Self::List(expr) => expr.evaluate(exec),
@@ -158,20 +154,15 @@ impl LazyValue {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyValue {
-    fn fmt<'tree>(
-        &self,
-        f: &mut fmt::Formatter,
-        ctx: &Context,
-        graph: &Graph<'tree>,
-    ) -> fmt::Result {
+impl fmt::Display for LazyValue {
+    fn fmt<'tree>(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Value(value) => write!(f, "{}", value),
-            Self::List(expr) => expr.fmt(f, ctx, graph),
-            Self::Set(expr) => expr.fmt(f, ctx, graph),
-            Self::Variable(expr) => expr.fmt(f, ctx, graph),
-            Self::ScopedVariable(expr) => expr.fmt(f, ctx, graph),
-            Self::Call(expr) => expr.fmt(f, ctx, graph),
+            Self::List(expr) => expr.fmt(f),
+            Self::Set(expr) => expr.fmt(f),
+            Self::Variable(expr) => expr.fmt(f),
+            Self::ScopedVariable(expr) => expr.fmt(f),
+            Self::Call(expr) => expr.fmt(f),
         }
     }
 }
@@ -194,7 +185,7 @@ impl LazyScopedVariable {
     fn resolve<'a>(&self, exec: &'a mut EvaluationContext) -> Result<LazyValue, ExecutionError> {
         let scope = self.scope.as_ref().evaluate_as_syntax_node(exec)?;
         let scoped_store = &exec.scoped_store;
-        scoped_store.evaluate(scope, self.name, exec)
+        scoped_store.evaluate(&scope, &self.name, exec)
     }
 
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<Value, ExecutionError> {
@@ -203,14 +194,9 @@ impl LazyScopedVariable {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyScopedVariable {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
-        write!(
-            f,
-            "(scoped {} '{})",
-            self.scope.display_with(ctx, graph),
-            self.name.display_with(ctx),
-        )
+impl fmt::Display for LazyScopedVariable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(scoped {} '{})", self.scope, self.name,)
     }
 }
 
@@ -235,16 +221,16 @@ impl LazyList {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyList {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+impl fmt::Display for LazyList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "(list")?;
         let mut first = true;
         for elem in &self.elements {
             if first {
                 first = false;
-                write!(f, "{}", elem.display_with(ctx, graph))?;
+                write!(f, "{}", elem)?;
             } else {
-                write!(f, " {}", elem.display_with(ctx, graph))?;
+                write!(f, " {}", elem)?;
             }
         }
         write!(f, ")")
@@ -272,16 +258,16 @@ impl LazySet {
     }
 }
 
-impl DisplayWithContextAndGraph for LazySet {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+impl fmt::Display for LazySet {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "(set")?;
         let mut first = true;
         for elem in &self.elements {
             if first {
                 first = false;
-                write!(f, "{}", elem.display_with(ctx, graph))?;
+                write!(f, "{}", elem)?;
             } else {
-                write!(f, " {}", elem.display_with(ctx, graph))?;
+                write!(f, " {}", elem)?;
             }
         }
         write!(f, ")")
@@ -310,8 +296,7 @@ impl LazyCall {
         }
 
         exec.functions.call(
-            exec.ctx,
-            self.function,
+            &self.function,
             exec.graph,
             exec.source,
             &mut exec
@@ -321,11 +306,11 @@ impl LazyCall {
     }
 }
 
-impl DisplayWithContextAndGraph for LazyCall {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
-        write!(f, "(call '{}", self.function.display_with(ctx))?;
+impl fmt::Display for LazyCall {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(call '{}", self.function)?;
         for arg in &self.arguments {
-            write!(f, " {}", arg.display_with(ctx, graph))?;
+            write!(f, " {}", arg)?;
         }
         write!(f, ")")
     }

--- a/src/lazy_execution/values.rs
+++ b/src/lazy_execution/values.rs
@@ -13,7 +13,6 @@ use std::convert::From;
 use std::fmt;
 
 use crate::execution::ExecutionError;
-use crate::graph::DisplayWithGraph;
 use crate::graph::Graph;
 use crate::graph::GraphNodeRef;
 use crate::graph::SyntaxNodeRef;
@@ -132,7 +131,7 @@ impl LazyValue {
             Self::ScopedVariable(expr) => expr.evaluate(exec),
             Self::Call(expr) => expr.evaluate(exec),
         }?;
-        trace!("}} = {}", ret.display_with(exec.graph));
+        trace!("}} = {}", ret);
         Ok(ret)
     }
 
@@ -143,10 +142,7 @@ impl LazyValue {
         let node = self.evaluate(exec)?;
         match node {
             Value::GraphNode(node) => Ok(node),
-            _ => Err(ExecutionError::ExpectedGraphNode(format!(
-                " got {}",
-                node.display_with(exec.graph)
-            ))),
+            _ => Err(ExecutionError::ExpectedGraphNode(format!(" got {}", node))),
         }
     }
 
@@ -157,10 +153,7 @@ impl LazyValue {
         let node = self.evaluate(exec)?;
         match node {
             Value::SyntaxNode(node) => Ok(node),
-            _ => Err(ExecutionError::ExpectedSyntaxNode(format!(
-                " got {}",
-                node.display_with(exec.graph)
-            ))),
+            _ => Err(ExecutionError::ExpectedSyntaxNode(format!(" got {}", node))),
         }
     }
 }
@@ -173,7 +166,7 @@ impl DisplayWithContextAndGraph for LazyValue {
         graph: &Graph<'tree>,
     ) -> fmt::Result {
         match self {
-            Self::Value(value) => write!(f, "{}", value.display_with(graph)),
+            Self::Value(value) => write!(f, "{}", value),
             Self::List(expr) => expr.fmt(f, ctx, graph),
             Self::Set(expr) => expr.fmt(f, ctx, graph),
             Self::Variable(expr) => expr.fmt(f, ctx, graph),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ pub use execution::Globals as Variables;
 pub use parser::Location;
 pub use parser::ParseError;
 
+use std::borrow::Borrow;
+use std::hash::Hash;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -49,7 +51,7 @@ use serde::Serialize;
 use serde::Serializer;
 
 /// An identifier that appears in a graph DSL file or in the graph that is produced as an output.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Identifier(Rc<String>);
 
 impl Identifier {
@@ -60,6 +62,12 @@ impl Identifier {
     pub fn into_string(mut self) -> String {
         Rc::make_mut(&mut self.0);
         Rc::try_unwrap(self.0).unwrap()
+    }
+}
+
+impl Borrow<str> for Identifier {
+    fn borrow(&self) -> &str {
+        self.as_str()
     }
 }
 
@@ -79,6 +87,12 @@ impl std::fmt::Display for Identifier {
 impl From<&str> for Identifier {
     fn from(value: &str) -> Identifier {
         Identifier(Rc::new(String::from(value)))
+    }
+}
+
+impl Hash for Identifier {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,73 +42,60 @@ pub use execution::Globals as Variables;
 pub use parser::Location;
 pub use parser::ParseError;
 
-use string_interner::symbol::SymbolU32;
-use string_interner::StringInterner;
+use std::ops::Deref;
+use std::rc::Rc;
 
-use std::fmt;
+use serde::Serialize;
+use serde::Serializer;
 
 /// An identifier that appears in a graph DSL file or in the graph that is produced as an output.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Identifier(SymbolU32);
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Identifier(Rc<String>);
 
-impl DisplayWithContext for Identifier {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(f, "{}", ctx.identifiers.resolve(self.0).unwrap())
+impl Identifier {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn into_string(mut self) -> String {
+        Rc::make_mut(&mut self.0);
+        Rc::try_unwrap(self.0).unwrap()
     }
 }
 
-/// A context in which graph DSL files are executed.
-#[derive(Default)]
-pub struct Context {
-    identifiers: StringInterner,
-}
-
-impl Context {
-    /// Creates a new, empty execution context.
-    pub fn new() -> Context {
-        Context::default()
-    }
-
-    /// Adds an identifier to the context.
-    #[inline(always)]
-    pub fn add_identifier<T: AsRef<str>>(&mut self, identifier: T) -> Identifier {
-        Identifier(self.identifiers.get_or_intern(identifier))
-    }
-
-    /// Returns the [`Identifier`][] instance for an identifier, if it has already been added to
-    /// the context.  Returns `None` otherwise.
-    #[inline(always)]
-    pub fn get_identifier<T: AsRef<str>>(&self, identifier: T) -> Option<Identifier> {
-        self.identifiers.get(identifier).map(Identifier)
-    }
-
-    pub fn resolve(&self, identifier: Identifier) -> &str {
-        self.identifiers.resolve(identifier.0).unwrap()
+impl Deref for Identifier {
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.as_str()
     }
 }
 
-/// Trait to Display with a given Context
-pub trait DisplayWithContext
-where
-    Self: Sized,
-{
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result;
-
-    fn display_with<'a>(&'a self, ctx: &'a Context) -> Box<dyn fmt::Display + 'a> {
-        struct Impl<'a, T: DisplayWithContext>(&'a T, &'a Context);
-
-        impl<'a, T: DisplayWithContext> fmt::Display for Impl<'a, T> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                self.0.fmt(f, self.1)
-            }
-        }
-
-        Box::new(Impl(self, ctx))
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
-impl<T: DisplayWithContext> DisplayWithContext for Box<T> {
-    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        self.as_ref().fmt(f, ctx)
+impl From<&str> for Identifier {
+    fn from(value: &str) -> Identifier {
+        Identifier(Rc::new(String::from(value)))
+    }
+}
+
+impl PartialEq<str> for Identifier {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl<'a> PartialEq<&'a str> for Identifier {
+    fn eq(&self, other: &&'a str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl Serialize for Identifier {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
     }
 }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -111,7 +111,7 @@ impl<V> Variables<V> for VariableMap<'_, V> {
 
     fn get(&self, name: &Identifier) -> Option<&V> {
         self.values
-            .get(&name)
+            .get(name)
             .map(|v| &v.value)
             .or_else(|| self.parent.as_ref().map(|p| p.get(name)).flatten())
     }

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -9,8 +9,8 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
-use tree_sitter_graph::Context;
 use tree_sitter_graph::ExecutionError;
+use tree_sitter_graph::Identifier;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -27,16 +27,15 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     let mut parser = Parser::new();
     parser.set_language(tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();
-    let mut ctx = Context::new();
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, dsl_source)
-        .expect("Cannot parse file");
-    let mut functions = Functions::stdlib(&mut ctx);
+    let file =
+        File::from_str(tree_sitter_python::language(), dsl_source).expect("Cannot parse file");
+    let mut functions = Functions::stdlib();
     let mut globals = Variables::new();
     globals
-        .add(ctx.add_identifier("filename"), "test.py".into())
+        .add(Identifier::from("filename"), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
-    let graph = file.execute(&ctx, &tree, python_source, &mut functions, &mut globals)?;
-    let result = graph.display_with(&ctx).to_string();
+    let graph = file.execute(&tree, python_source, &mut functions, &mut globals)?;
+    let result = graph.pretty_print().to_string();
     Ok(result)
 }
 

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -19,7 +19,7 @@ fn can_overwrite_attributes() {
     let name = Identifier::from("name");
     attrs.add(name.clone(), "node0").unwrap();
     attrs.add(name.clone(), "overwritten").unwrap_err();
-    assert_eq!(*attrs.get(name).unwrap(), Value::from("overwritten"));
+    assert_eq!(*attrs.get(&name).unwrap(), Value::from("overwritten"));
 }
 
 #[test]

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -9,17 +9,16 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::graph::Graph;
 use tree_sitter_graph::graph::Value;
-use tree_sitter_graph::Context;
+use tree_sitter_graph::Identifier;
 
 #[test]
 fn can_overwrite_attributes() {
-    let mut ctx = Context::new();
     let mut graph = Graph::new();
     let node = graph.add_graph_node();
     let attrs = &mut graph[node].attributes;
-    let name = ctx.add_identifier("name");
-    attrs.add(name, "node0").unwrap();
-    attrs.add(name, "overwritten").unwrap_err();
+    let name = Identifier::from("name");
+    attrs.add(name.clone(), "node0").unwrap();
+    attrs.add(name.clone(), "overwritten").unwrap_err();
     assert_eq!(*attrs.get(name).unwrap(), Value::from("overwritten"));
 }
 
@@ -55,41 +54,40 @@ fn can_display_graph() {
     parser.set_language(tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();
 
-    let mut ctx = Context::new();
     let mut graph = Graph::new();
     let root = graph.add_syntax_node(tree.root_node());
     let node0 = graph.add_graph_node();
     graph[node0]
         .attributes
-        .add(ctx.add_identifier("name"), "node0")
+        .add(Identifier::from("name"), "node0")
         .unwrap();
     graph[node0]
         .attributes
-        .add(ctx.add_identifier("source"), root)
+        .add(Identifier::from("source"), root)
         .unwrap();
     let node1 = graph.add_graph_node();
     graph[node1]
         .attributes
-        .add(ctx.add_identifier("name"), "node1")
+        .add(Identifier::from("name"), "node1")
         .unwrap();
     let node2 = graph.add_graph_node();
     graph[node2]
         .attributes
-        .add(ctx.add_identifier("name"), "node2")
+        .add(Identifier::from("name"), "node2")
         .unwrap();
     graph[node2]
         .attributes
-        .add(ctx.add_identifier("parent"), node1)
+        .add(Identifier::from("parent"), node1)
         .unwrap();
     let edge01 = graph[node0]
         .add_edge(node1)
         .unwrap_or_else(|_| unreachable!());
     edge01
         .attributes
-        .add(ctx.add_identifier("precedence"), 14)
+        .add(Identifier::from("precedence"), 14)
         .unwrap();
     assert_eq!(
-        graph.display_with(&ctx).to_string(),
+        graph.pretty_print().to_string(),
         indoc! {r#"
           node 0
             name: "node0"

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -8,12 +8,11 @@
 use tree_sitter::CaptureQuantifier::*;
 
 use tree_sitter_graph::ast::*;
-use tree_sitter_graph::Context;
+use tree_sitter_graph::Identifier;
 use tree_sitter_graph::Location;
 
 #[test]
 fn can_parse_blocks() {
-    let mut ctx = Context::new();
     let source = r#"
         (function_definition
           name: (identifier) @cap1) @cap2
@@ -27,16 +26,15 @@ fn can_parse_blocks() {
           set @cap2.var1 = loc1
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let loc1 = ctx.add_identifier("loc1");
-    let precedence = ctx.add_identifier("precedence");
-    let pop = ctx.add_identifier("pop");
-    let prop1 = ctx.add_identifier("prop1");
-    let push = ctx.add_identifier("push");
-    let cap2 = ctx.add_identifier("cap2");
-    let var1 = ctx.add_identifier("var1");
+    let loc1 = Identifier::from("loc1");
+    let precedence = Identifier::from("precedence");
+    let pop = Identifier::from("pop");
+    let prop1 = Identifier::from("prop1");
+    let push = Identifier::from("push");
+    let cap2 = Identifier::from("cap2");
+    let var1 = Identifier::from("var1");
 
     let statements = file
         .stanzas
@@ -48,7 +46,7 @@ fn can_parse_blocks() {
         vec![vec![
             CreateGraphNode {
                 node: UnscopedVariable {
-                    name: loc1,
+                    name: loc1.clone(),
                     location: Location { row: 4, column: 15 }
                 }
                 .into(),
@@ -60,14 +58,14 @@ fn can_parse_blocks() {
                     scope: Box::new(
                         Capture {
                             quantifier: One,
-                            name: cap2,
+                            name: cap2.clone(),
                             file_capture_index: 1,
                             stanza_capture_index: 1,
                             location: Location { row: 5, column: 15 }
                         }
                         .into()
                     ),
-                    name: prop1,
+                    name: prop1.clone(),
                     location: Location { row: 5, column: 21 }
                 }
                 .into(),
@@ -79,19 +77,19 @@ fn can_parse_blocks() {
                     scope: Box::new(
                         Capture {
                             quantifier: One,
-                            name: cap2,
+                            name: cap2.clone(),
                             file_capture_index: 1,
                             stanza_capture_index: 1,
                             location: Location { row: 6, column: 15 }
                         }
                         .into()
                     ),
-                    name: prop1,
+                    name: prop1.clone(),
                     location: Location { row: 6, column: 21 }
                 }
                 .into(),
                 sink: UnscopedVariable {
-                    name: loc1,
+                    name: loc1.clone(),
                     location: Location { row: 6, column: 30 },
                 }
                 .into(),
@@ -103,19 +101,19 @@ fn can_parse_blocks() {
                     scope: Box::new(
                         Capture {
                             quantifier: One,
-                            name: cap2,
+                            name: cap2.clone(),
                             file_capture_index: 1,
                             stanza_capture_index: 1,
                             location: Location { row: 7, column: 16 }
                         }
                         .into()
                     ),
-                    name: prop1,
+                    name: prop1.clone(),
                     location: Location { row: 7, column: 22 },
                 }
                 .into(),
                 sink: UnscopedVariable {
-                    name: loc1.into(),
+                    name: loc1.clone(),
                     location: Location { row: 7, column: 31 },
                 }
                 .into(),
@@ -131,25 +129,25 @@ fn can_parse_blocks() {
                     scope: Box::new(
                         Capture {
                             quantifier: One,
-                            name: cap2,
+                            name: cap2.clone(),
                             file_capture_index: 1,
                             stanza_capture_index: 1,
                             location: Location { row: 8, column: 16 }
                         }
                         .into()
                     ),
-                    name: prop1,
+                    name: prop1.clone(),
                     location: Location { row: 8, column: 22 },
                 }
                 .into(),
                 attributes: vec![
                     Attribute {
-                        name: push,
+                        name: push.clone(),
                         value: String::from("str2").into(),
                     },
                     Attribute {
-                        name: pop,
-                        value: Expression::TrueLiteral
+                        name: pop.clone(),
+                        value: Expression::TrueLiteral,
                     },
                 ],
                 location: Location { row: 8, column: 10 },
@@ -160,19 +158,19 @@ fn can_parse_blocks() {
                     scope: Box::new(
                         Capture {
                             quantifier: One,
-                            name: cap2,
+                            name: cap2.clone(),
                             file_capture_index: 1,
                             stanza_capture_index: 1,
                             location: Location { row: 9, column: 14 }
                         }
                         .into()
                     ),
-                    name: var1,
+                    name: var1.clone(),
                     location: Location { row: 9, column: 20 },
                 }
                 .into(),
                 value: UnscopedVariable {
-                    name: loc1,
+                    name: loc1.clone(),
                     location: Location { row: 9, column: 27 },
                 }
                 .into(),
@@ -184,7 +182,7 @@ fn can_parse_blocks() {
                     scope: Box::new(
                         Capture {
                             quantifier: One,
-                            name: cap2,
+                            name: cap2.clone(),
                             file_capture_index: 1,
                             stanza_capture_index: 1,
                             location: Location {
@@ -194,7 +192,7 @@ fn can_parse_blocks() {
                         }
                         .into()
                     ),
-                    name: var1,
+                    name: var1.clone(),
                     location: Location {
                         row: 10,
                         column: 20
@@ -202,7 +200,7 @@ fn can_parse_blocks() {
                 }
                 .into(),
                 value: UnscopedVariable {
-                    name: loc1,
+                    name: loc1.clone(),
                     location: Location {
                         row: 10,
                         column: 27
@@ -221,7 +219,6 @@ fn can_parse_blocks() {
 
 #[test]
 fn can_parse_literals() {
-    let mut ctx = Context::new();
     let source = r#"
         (identifier)
         {
@@ -230,12 +227,11 @@ fn can_parse_literals() {
           let t = #true
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let f = ctx.add_identifier("f");
-    let n = ctx.add_identifier("n");
-    let t = ctx.add_identifier("t");
+    let f = Identifier::from("f");
+    let n = Identifier::from("n");
+    let t = Identifier::from("t");
 
     let statements = file
         .stanzas
@@ -247,7 +243,7 @@ fn can_parse_literals() {
         vec![vec![
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: f,
+                    name: f.clone(),
                     location: Location { row: 3, column: 14 }
                 }
                 .into(),
@@ -257,7 +253,7 @@ fn can_parse_literals() {
             .into(),
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: n,
+                    name: n.clone(),
                     location: Location { row: 4, column: 14 }
                 }
                 .into(),
@@ -267,7 +263,7 @@ fn can_parse_literals() {
             .into(),
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: t,
+                    name: t.clone(),
                     location: Location { row: 5, column: 14 }
                 }
                 .into(),
@@ -281,17 +277,15 @@ fn can_parse_literals() {
 
 #[test]
 fn can_parse_strings() {
-    let mut ctx = Context::new();
     let source = r#"
         (identifier)
         {
           let loc1 = "\"abc,\ndef\\"
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let loc1 = ctx.add_identifier("loc1");
+    let loc1 = Identifier::from("loc1");
 
     let statements = file
         .stanzas
@@ -302,7 +296,7 @@ fn can_parse_strings() {
         statements,
         vec![vec![DeclareImmutable {
             variable: UnscopedVariable {
-                name: loc1,
+                name: loc1.clone(),
                 location: Location { row: 3, column: 14 }
             }
             .into(),
@@ -315,7 +309,6 @@ fn can_parse_strings() {
 
 #[test]
 fn can_parse_lists() {
-    let mut ctx = Context::new();
     let source = r#"
         (identifier)
         {
@@ -324,12 +317,11 @@ fn can_parse_lists() {
           let list3 = ["hello", "world",]
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let list1 = ctx.add_identifier("list1");
-    let list2 = ctx.add_identifier("list2");
-    let list3 = ctx.add_identifier("list3");
+    let list1 = Identifier::from("list1");
+    let list2 = Identifier::from("list2");
+    let list3 = Identifier::from("list3");
 
     let statements = file
         .stanzas
@@ -341,7 +333,7 @@ fn can_parse_lists() {
         vec![vec![
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: list1,
+                    name: list1.clone(),
                     location: Location { row: 3, column: 14 }
                 }
                 .into(),
@@ -358,7 +350,7 @@ fn can_parse_lists() {
             .into(),
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: list2,
+                    name: list2.clone(),
                     location: Location { row: 4, column: 14 }
                 }
                 .into(),
@@ -368,7 +360,7 @@ fn can_parse_lists() {
             .into(),
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: list3,
+                    name: list3.clone(),
                     location: Location { row: 5, column: 14 }
                 }
                 .into(),
@@ -394,7 +386,6 @@ fn can_parse_lists() {
 
 #[test]
 fn can_parse_sets() {
-    let mut ctx = Context::new();
     let source = r#"
         (identifier)
         {
@@ -403,12 +394,11 @@ fn can_parse_sets() {
           let set3 = {"hello", "world",}
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let set1 = ctx.add_identifier("set1");
-    let set2 = ctx.add_identifier("set2");
-    let set3 = ctx.add_identifier("set3");
+    let set1 = Identifier::from("set1");
+    let set2 = Identifier::from("set2");
+    let set3 = Identifier::from("set3");
 
     let statements = file
         .stanzas
@@ -420,7 +410,7 @@ fn can_parse_sets() {
         vec![vec![
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: set1,
+                    name: set1.clone(),
                     location: Location { row: 3, column: 14 }
                 }
                 .into(),
@@ -437,7 +427,7 @@ fn can_parse_sets() {
             .into(),
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: set2,
+                    name: set2.clone(),
                     location: Location { row: 4, column: 14 }
                 }
                 .into(),
@@ -447,7 +437,7 @@ fn can_parse_sets() {
             .into(),
             DeclareImmutable {
                 variable: UnscopedVariable {
-                    name: set3,
+                    name: set3.clone(),
                     location: Location { row: 5, column: 14 }
                 }
                 .into(),
@@ -473,15 +463,13 @@ fn can_parse_sets() {
 
 #[test]
 fn can_parse_print() {
-    let mut ctx = Context::new();
     let source = r#"
         (identifier)
         {
           print "x =", 5
         }    
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
     let statements = file
         .stanzas
@@ -506,7 +494,6 @@ fn can_parse_print() {
 
 #[test]
 fn cannot_parse_nullable_regex() {
-    let mut ctx = Context::new();
     let source = r#"
         (module) @root
         {
@@ -517,24 +504,22 @@ fn cannot_parse_nullable_regex() {
           node n
         }
     "#;
-    if let Ok(_) = File::from_str(tree_sitter_python::language(), &mut ctx, source) {
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
         panic!("Parse succeeded unexpectedly");
     }
 }
 
 #[test]
 fn can_parse_star_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_)* @stmts)
         {
           print @stmts
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let stmts = ctx.add_identifier("stmts");
+    let stmts = Identifier::from("stmts");
 
     let statements = file
         .stanzas
@@ -560,7 +545,6 @@ fn can_parse_star_capture() {
 
 #[test]
 fn can_parse_star_multiple_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_) @stmt * @stmts)
         {
@@ -568,11 +552,10 @@ fn can_parse_star_multiple_capture() {
           print @stmts
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("stmt");
-    let stmts = ctx.add_identifier("stmts");
+    let stmt = Identifier::from("stmt");
+    let stmts = Identifier::from("stmts");
 
     let statements = file
         .stanzas
@@ -612,17 +595,15 @@ fn can_parse_star_multiple_capture() {
 
 #[test]
 fn can_parse_plus_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_)+ @stmts)
         {
           print @stmts
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let stmts = ctx.add_identifier("stmts");
+    let stmts = Identifier::from("stmts");
 
     let statements = file
         .stanzas
@@ -648,17 +629,15 @@ fn can_parse_plus_capture() {
 
 #[test]
 fn can_parse_optional_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_)? @stmt)
         {
           print @stmt
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("stmt");
+    let stmt = Identifier::from("stmt");
 
     let statements = file
         .stanzas
@@ -684,17 +663,15 @@ fn can_parse_optional_capture() {
 
 #[test]
 fn can_parse_parent_optional_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_) @stmt) ?
         {
           print @stmt
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("stmt");
+    let stmt = Identifier::from("stmt");
 
     let statements = file
         .stanzas
@@ -720,17 +697,15 @@ fn can_parse_parent_optional_capture() {
 
 #[test]
 fn can_parse_alternative_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module [(_) (_) @stmt])
         {
           print @stmt
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("stmt");
+    let stmt = Identifier::from("stmt");
 
     let statements = file
         .stanzas
@@ -756,17 +731,15 @@ fn can_parse_alternative_capture() {
 
 #[test]
 fn can_parse_nested_plus_and_optional_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_)+ @stmt) ?
         {
           print @stmt
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("stmt");
+    let stmt = Identifier::from("stmt");
 
     let statements = file
         .stanzas
@@ -792,7 +765,6 @@ fn can_parse_nested_plus_and_optional_capture() {
 
 #[test]
 fn can_parse_if() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (pass_statement)? @x)
         {
@@ -801,10 +773,9 @@ fn can_parse_if() {
           }
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let x = ctx.add_identifier("x");
+    let x = Identifier::from("x");
 
     let statements = file
         .stanzas
@@ -844,7 +815,6 @@ fn can_parse_if() {
 
 #[test]
 fn can_parse_if_elif() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (pass_statement)? @x)
         {
@@ -855,10 +825,9 @@ fn can_parse_if_elif() {
           }
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let x = ctx.add_identifier("x");
+    let x = Identifier::from("x");
 
     let statements = file
         .stanzas
@@ -873,7 +842,7 @@ fn can_parse_if_elif() {
                     conditions: vec![Condition::None {
                         value: Capture {
                             quantifier: ZeroOrOne,
-                            name: x,
+                            name: x.clone(),
                             file_capture_index: 0,
                             stanza_capture_index: 0,
                             location: Location { row: 3, column: 18 },
@@ -896,7 +865,7 @@ fn can_parse_if_elif() {
                     conditions: vec![Condition::Some {
                         value: Capture {
                             quantifier: ZeroOrOne,
-                            name: x,
+                            name: x.clone(),
                             file_capture_index: 0,
                             stanza_capture_index: 0,
                             location: Location { row: 5, column: 22 },
@@ -923,7 +892,6 @@ fn can_parse_if_elif() {
 
 #[test]
 fn can_parse_if_else() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (pass_statement)? @x)
         {
@@ -934,10 +902,9 @@ fn can_parse_if_else() {
           }
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let x = ctx.add_identifier("x");
+    let x = Identifier::from("x");
 
     let statements = file
         .stanzas
@@ -991,7 +958,6 @@ fn can_parse_if_else() {
 
 #[test]
 fn cannot_parse_if_some_list_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_)+ @xs) @root
         {
@@ -1000,14 +966,13 @@ fn cannot_parse_if_some_list_capture() {
           }
         }
     "#;
-    if let Ok(_) = File::from_str(tree_sitter_python::language(), &mut ctx, source) {
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
         panic!("Parse succeeded unexpectedly");
     }
 }
 
 #[test]
 fn can_parse_for_in() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_)* @xs)
         {
@@ -1016,11 +981,10 @@ fn can_parse_for_in() {
           }
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), &mut ctx, source)
-        .expect("Cannot parse file");
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
 
-    let xs = ctx.add_identifier("xs");
-    let x = ctx.add_identifier("x");
+    let xs = Identifier::from("xs");
+    let x = Identifier::from("x");
 
     let statements = file
         .stanzas
@@ -1031,12 +995,12 @@ fn can_parse_for_in() {
         statements,
         vec![vec![ForIn {
             variable: UnscopedVariable {
-                name: x,
+                name: x.clone(),
                 location: Location { row: 3, column: 14 }
             },
             value: Capture {
                 quantifier: ZeroOrMore,
-                name: xs,
+                name: xs.clone(),
                 file_capture_index: 0,
                 stanza_capture_index: 0,
                 location: Location { row: 3, column: 19 },
@@ -1044,7 +1008,7 @@ fn can_parse_for_in() {
             .into(),
             statements: vec![Print {
                 values: vec![UnscopedVariable {
-                    name: x,
+                    name: x.clone(),
                     location: Location { row: 4, column: 18 },
                 }
                 .into()],
@@ -1059,7 +1023,6 @@ fn can_parse_for_in() {
 
 #[test]
 fn cannot_parse_for_in_optional_capture() {
-    let mut ctx = Context::new();
     let source = r#"
         (module (_)? @xs) @root
         {
@@ -1068,14 +1031,13 @@ fn cannot_parse_for_in_optional_capture() {
           }
         }
     "#;
-    if let Ok(_) = File::from_str(tree_sitter_python::language(), &mut ctx, source) {
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
         panic!("Parse succeeded unexpectedly");
     }
 }
 
 #[test]
 fn cannot_parse_scan_of_nonlocal_call_expression() {
-    let mut ctx = Context::new();
     let source = r#"
       (function_definition
       name: (identifier) @name)
@@ -1088,14 +1050,13 @@ fn cannot_parse_scan_of_nonlocal_call_expression() {
         }
       }
     "#;
-    if let Ok(_) = File::from_str(tree_sitter_python::language(), &mut ctx, source) {
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
         panic!("Parse succeeded unexpectedly");
     }
 }
 
 #[test]
 fn cannot_parse_scan_of_nonlocal_variable() {
-    let mut ctx = Context::new();
     let source = r#"
       (function_definition
       name: (identifier) @name)
@@ -1109,7 +1070,7 @@ fn cannot_parse_scan_of_nonlocal_variable() {
         }
       }
     "#;
-    if let Ok(_) = File::from_str(tree_sitter_python::language(), &mut ctx, source) {
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
         panic!("Parse succeeded unexpectedly");
     }
 }


### PR DESCRIPTION
In retrospect I think this was a premature optimization.  We have to spend a decent amount of time hashing the identifier strings in order to dedup them, and it's not at all obvious that that's less time than it takes to just compare the (small) strings directly.  So now Identifiers are just a wrapper around a reference-counted `String`.  This lets us get rid of the `Context` object completely, greatly simplifying our `Display` logic and several type signatures.

There is more that we could do here — for instance, allowing the content of an Identifier to be a slice into the DSL file — but this is the minimal change that gets rid of `Context`.