### PR TITLE
Add support for nested function calls

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -530,7 +530,6 @@ impl Capture {
 
 impl Call {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
-        exec.function_parameters.clear();
         for parameter in &self.parameters {
             let parameter = parameter.evaluate(exec)?;
             exec.function_parameters.push(parameter);
@@ -540,7 +539,9 @@ impl Call {
             self.function,
             exec.graph,
             exec.source,
-            &mut exec.function_parameters.drain(..),
+            &mut exec
+                .function_parameters
+                .drain(exec.function_parameters.len() - self.parameters.len()..),
         )
     }
 }

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -176,3 +176,21 @@ fn can_match_stanza_multiple_times() {
         "#},
     );
 }
+
+#[test]
+fn can_nest_function_calls() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            attr (node0) val = (replace "accacc" (replace "abc" "b" "c") (replace "abc" "a" "b"))
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: "bbcbbc"
+        "#},
+    );
+}


### PR DESCRIPTION
A fairly straightforward implementation. Rather than draining the entire
list of parameters from `exec.function_parameters` when calling a
function, we just drain the last `N` where `N` is the number of
arguments passed to the function.

The added test (hopefully) demonstrates that this works correctly.
Without the changes in this PR, execution would panic when the outer
`replace` call was called without arguments (as these would have been
purged by the second call).