### PR TITLE
Support capture existence testing and simple control flow

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -451,6 +451,8 @@ pub enum Expression {
     Set(SetComprehension),
     // Syntax nodes
     Capture(Capture),
+    // Existence of capture
+    CaptureExists(CaptureExists),
     // Variables
     Variable(Variable),
     // Functions
@@ -470,6 +472,7 @@ impl DisplayWithContext for Expression {
             Expression::List(expr) => expr.fmt(f, ctx),
             Expression::Set(expr) => expr.fmt(f, ctx),
             Expression::Capture(expr) => expr.fmt(f, ctx),
+            Expression::CaptureExists(expr) => expr.fmt(f, ctx),
             Expression::Variable(expr) => expr.fmt(f, ctx),
             Expression::Call(expr) => expr.fmt(f, ctx),
             Expression::RegexCapture(expr) => expr.fmt(f, ctx),
@@ -518,6 +521,24 @@ impl From<Capture> for Expression {
 impl DisplayWithContext for Capture {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
         write!(f, "{}", self.name.display_with(ctx))
+    }
+}
+
+/// An expression that checks whether a capture exists
+#[derive(Debug, Eq, PartialEq)]
+pub struct CaptureExists {
+    pub capture: Capture,
+}
+
+impl From<CaptureExists> for Expression {
+    fn from(expr: CaptureExists) -> Expression {
+        Expression::CaptureExists(expr)
+    }
+}
+
+impl DisplayWithContext for CaptureExists {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+        write!(f, "?{}", self.capture.display_with(ctx))
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -59,6 +59,8 @@ pub enum Statement {
     AddEdgeAttribute(AddEdgeAttribute),
     // Regular expression
     Scan(Scan),
+    // Control flow
+    If(If),
     // Debugging
     Print(Print),
 }
@@ -74,6 +76,7 @@ impl DisplayWithContext for Statement {
             Statement::CreateEdge(stmt) => stmt.fmt(f, ctx),
             Statement::AddEdgeAttribute(stmt) => stmt.fmt(f, ctx),
             Statement::Scan(stmt) => stmt.fmt(f, ctx),
+            Statement::If(stmt) => stmt.fmt(f, ctx),
             Statement::Print(stmt) => stmt.fmt(f, ctx),
         }
     }
@@ -346,6 +349,26 @@ impl PartialEq for ScanArm {
 impl DisplayWithContext for ScanArm {
     fn fmt(&self, f: &mut fmt::Formatter, _ctx: &Context) -> fmt::Result {
         write!(f, "{:?} {{ ... }}", self.regex.as_str())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct If {
+    pub condition: Expression,
+    pub consequence: Vec<Statement>,
+    pub location: Location,
+}
+
+impl From<If> for Statement {
+    fn from(statement: If) -> Statement {
+        Statement::If(statement)
+    }
+}
+
+impl DisplayWithContext for If {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
+        write!(f, "if {} {{ ... }}", self.condition.display_with(ctx),)?;
+        Ok(())
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -18,6 +18,7 @@ use crate::ast::AddGraphNodeAttribute;
 use crate::ast::Assign;
 use crate::ast::Call;
 use crate::ast::Capture;
+use crate::ast::CaptureExists;
 use crate::ast::CreateEdge;
 use crate::ast::CreateGraphNode;
 use crate::ast::DeclareImmutable;
@@ -473,6 +474,7 @@ impl Expression {
             Expression::List(expr) => expr.evaluate(exec),
             Expression::Set(expr) => expr.evaluate(exec),
             Expression::Capture(expr) => expr.evaluate(exec),
+            Expression::CaptureExists(expr) => expr.evaluate(exec),
             Expression::Variable(expr) => expr.evaluate(exec),
             Expression::Call(expr) => expr.evaluate(exec),
             Expression::RegexCapture(expr) => expr.evaluate(exec),
@@ -541,6 +543,16 @@ impl Capture {
             "{}",
             self.display_with(exec.ctx)
         )))
+    }
+}
+
+impl CaptureExists {
+    fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
+        match self.capture.evaluate(exec) {
+            Err(ExecutionError::UndefinedCapture(_)) => Ok(Value::Boolean(false)),
+            Ok(_) => Ok(Value::Boolean(true)),
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -24,6 +24,7 @@ use crate::ast::DeclareImmutable;
 use crate::ast::DeclareMutable;
 use crate::ast::Expression;
 use crate::ast::File;
+use crate::ast::If;
 use crate::ast::IntegerConstant;
 use crate::ast::ListComprehension;
 use crate::ast::Print;
@@ -100,6 +101,8 @@ pub enum ExecutionError {
     ExpectedInteger(String),
     #[error("Expected a string {0}")]
     ExpectedString(String),
+    #[error("Expected a boolean {0}")]
+    ExpectedBoolean(String),
     #[error("Expected a syntax node {0}")]
     ExpectedSyntaxNode(String),
     #[error("Invalid parameters {0}")]
@@ -275,6 +278,7 @@ impl Statement {
             Statement::CreateEdge(statement) => statement.execute(exec),
             Statement::AddEdgeAttribute(statement) => statement.execute(exec),
             Statement::Scan(statement) => statement.execute(exec),
+            Statement::If(statement) => statement.execute(exec),
             Statement::Print(statement) => statement.execute(exec),
         }
     }
@@ -431,6 +435,18 @@ impl Scan {
             i += regex_captures.get(0).unwrap().range().end;
         }
 
+        Ok(())
+    }
+}
+
+impl If {
+    fn execute(&self, exec: &mut ExecutionContext) -> Result<(), ExecutionError> {
+        let condition = self.condition.evaluate(exec)?;
+        if condition.into_boolean(exec.graph)? {
+            for statement in &self.consequence {
+                statement.execute(exec)?;
+            }
+        }
         Ok(())
     }
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -530,7 +530,6 @@ impl Capture {
 
 impl Call {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
-        exec.function_parameters.clear();
         for parameter in &self.parameters {
             let parameter = parameter.evaluate(exec)?;
             exec.function_parameters.push(parameter);
@@ -540,7 +539,9 @@ impl Call {
             self.function,
             exec.graph,
             exec.source,
-            &mut exec.function_parameters.drain(..),
+            &mut exec
+                .function_parameters
+                .drain(exec.function_parameters.len() - self.parameters.len()..),
         )
     }
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -115,6 +115,9 @@ impl Functions {
             ctx.add_identifier("named-child-count"),
             stdlib::NamedChildCount,
         );
+        functions.add(ctx.add_identifier("and"), stdlib::And);
+        functions.add(ctx.add_identifier("or"), stdlib::Or);
+        functions.add(ctx.add_identifier("not"), stdlib::Not);
         functions
     }
 
@@ -357,6 +360,61 @@ pub mod stdlib {
             let node = parameters.param()?.into_syntax_node(graph)?;
             parameters.finish()?;
             Ok(Value::Integer(node.named_child_count() as u32))
+        }
+    }
+
+    // The implementation of the standard [`and`][`crate::reference::functions#and`] function.
+
+    pub struct And;
+
+    impl Function for And {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let mut result = true;
+            while let Ok(parameter) = parameters.param() {
+                result &= parameter.into_boolean(graph)?;
+            }
+            Ok(Value::Boolean(result))
+        }
+    }
+
+    // The implementation of the standard [`or`][`crate::reference::functions#or`] function.
+
+    pub struct Or;
+
+    impl Function for Or {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let mut result = false;
+            while let Ok(parameter) = parameters.param() {
+                result |= parameter.into_boolean(graph)?;
+            }
+            Ok(Value::Boolean(result))
+        }
+    }
+
+    // The implementation of the standard [`not`][`crate::reference::functions#not`] function.
+
+    pub struct Not;
+
+    impl Function for Not {
+        fn call(
+            &mut self,
+            graph: &mut Graph,
+            _source: &str,
+            parameters: &mut dyn Parameters,
+        ) -> Result<Value, ExecutionError> {
+            let parameter = parameters.param()?;
+            parameters.finish()?;
+            Ok(Value::Boolean(!parameter.into_boolean(graph)?))
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -277,6 +277,17 @@ impl Value {
         }
     }
 
+    /// Coerces this value into a boolean, returning an error if it's some other type of value.
+    pub fn into_boolean(self, graph: &Graph) -> Result<bool, ExecutionError> {
+        match self {
+            Value::Boolean(value) => Ok(value),
+            _ => Err(ExecutionError::ExpectedBoolean(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
+    }
+
     /// Coerces this value into a syntax node reference, returning an error if it's some other type
     /// of value.
     pub fn into_syntax_node<'a, 'tree>(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,6 +95,7 @@ struct Parser<'a> {
     set_keyword: Identifier,
     true_keyword: Identifier,
     var_keyword: Identifier,
+    if_keyword: Identifier,
 }
 
 fn is_ident_start(c: char) -> bool {
@@ -119,6 +120,7 @@ impl<'a> Parser<'a> {
         let set_keyword = ctx.add_identifier("set");
         let true_keyword = ctx.add_identifier("true");
         let var_keyword = ctx.add_identifier("var");
+        let if_keyword = ctx.add_identifier("if");
         Parser {
             ctx,
             source,
@@ -136,6 +138,7 @@ impl<'a> Parser<'a> {
             set_keyword,
             true_keyword,
             var_keyword,
+            if_keyword,
         }
     }
 }
@@ -433,6 +436,16 @@ impl Parser<'_> {
             Ok(ast::Scan {
                 value,
                 arms,
+                location: keyword_location,
+            }
+            .into())
+        } else if keyword == self.if_keyword {
+            let condition = self.parse_expression(current_query)?;
+            self.consume_whitespace();
+            let consequence = self.parse_statements(current_query)?;
+            Ok(ast::If {
+                condition,
+                consequence,
                 location: keyword_location,
             }
             .into())

--- a/src/reference/functions.rs
+++ b/src/reference/functions.rs
@@ -124,3 +124,24 @@
 //!     - `node`: A syntax node
 //!   - Output parameter:
 //!     - The zero-based end row of `node`
+//!
+//! ## `and`
+//!
+//! Returns true if and only if all of the input parameters are true.
+//!
+//!   - Input parameters: zero or more expressions evaluating to boolean values
+//!   - Output parameter: the boolean conjunction of all of the input parameters
+//!
+//! ## `or`
+//!
+//! Returns true if and only if at least one of the input parameters is true.
+//!
+//!   - Input parameters: zero or more expressions evaluating to boolean values
+//!   - Output parameter: the boolean disjunction of all of the input parameters
+//!
+//! ## `not`
+//!
+//! Returns the negation of the input parameter.
+//!
+//!   - Input parameters: one expression evaluating to a boolean value
+//!   - Output parameter: the negation of the input parameter

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -218,3 +218,31 @@ fn can_use_if_statements() {
         "#},
     );
 }
+
+#[test]
+fn can_check_existence_of_capture() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (expression_statement)? @expr) @root
+          {
+            node node0
+            attr (node0) has_root = ?@root
+            attr (node0) has_expr = ? @expr
+            if (not ?@expr) {
+              attr (node0) no_expr = "true"
+            }
+            if (or ?@root ?@expr) {
+              attr (node0) has_root_or_expr = "true"
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            has_root: #true
+            has_expr: #false
+            no_expr: "true"
+            has_root_or_expr: "true"
+        "#},
+    );
+}

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -176,3 +176,21 @@ fn can_match_stanza_multiple_times() {
         "#},
     );
 }
+
+#[test]
+fn can_nest_function_calls() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            attr (node0) val = (replace "accacc" (replace "abc" "b" "c") (replace "abc" "a" "b"))
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: "bbcbbc"
+        "#},
+    );
+}

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -194,3 +194,27 @@ fn can_nest_function_calls() {
         "#},
     );
 }
+
+#[test]
+fn can_use_if_statements() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            let t = #true
+            if t {
+              attr (node0) tval = "true"
+            }
+            if #false {
+              attr (node0) fval = "false"
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            tval: "true"
+        "#},
+    );
+}


### PR DESCRIPTION
Adds support for `if` statements and a prefix operator `?` that can be used to test for the presence of a given capture.

Thus, a stanza like
```
(module . (expression_statement)? @first) @root
{
  node @root.node
  if ?@first {
    attr (@root.node) first_expr = @first
  }
}
```
will set the `first_expr` attribute only in the case where the first statement in the input is in fact an expression.

In addition to this, this PR also adds functions for the usual boolean operators `and`, `or`, and `not`.

Can be reviewed commit-by-commit.