### PR TITLE
Fix `print` statement

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -438,14 +438,14 @@ impl Scan {
 impl Print {
     fn execute(&self, exec: &mut ExecutionContext) -> Result<(), ExecutionError> {
         for value in &self.values {
-            let value = value.evaluate(exec)?;
-            if let Value::String(s) = value {
-                print!("{}", s);
+            if let Expression::StringConstant(expr) = value {
+                eprint!("{}", expr.value);
             } else {
-                print!("{}", value.display_with(exec.graph));
+                let value = value.evaluate(exec)?;
+                eprint!("{}", value.display_with(exec.graph));
             }
         }
-        println!();
+        eprintln!();
         Ok(())
     }
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -439,9 +439,13 @@ impl Print {
     fn execute(&self, exec: &mut ExecutionContext) -> Result<(), ExecutionError> {
         for value in &self.values {
             let value = value.evaluate(exec)?;
-            print!("{}", value.display_with(exec.graph));
+            if let Value::String(s) = value {
+                print!("{}", s);
+            } else {
+                print!("{}", value.display_with(exec.graph));
+            }
         }
-        println!("");
+        println!();
         Ok(())
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -162,6 +162,7 @@ impl Parser<'_> {
         Ok(ch)
     }
 
+    #[allow(dead_code)]
     fn try_next(&mut self) -> Option<char> {
         self.next().ok()
     }
@@ -396,10 +397,13 @@ impl Parser<'_> {
         } else if keyword == self.print_keyword {
             let mut values = vec![self.parse_expression(current_query)?];
             self.consume_whitespace();
-            while self.try_next() == Some(',') {
+            while self.peek()? == ',' {
+                self.consume_token(",")?;
+                self.consume_whitespace();
                 values.push(self.parse_expression(current_query)?);
                 self.consume_whitespace();
             }
+            self.consume_whitespace();
             Ok(ast::Print {
                 values,
                 location: keyword_location,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -162,11 +162,6 @@ impl Parser<'_> {
         Ok(ch)
     }
 
-    #[allow(dead_code)]
-    fn try_next(&mut self) -> Option<char> {
-        self.next().ok()
-    }
-
     fn skip(&mut self) -> Result<(), ParseError> {
         self.next().map(|_| ())
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -392,7 +392,7 @@ impl Parser<'_> {
         } else if keyword == self.print_keyword {
             let mut values = vec![self.parse_expression(current_query)?];
             self.consume_whitespace();
-            while self.peek()? == ',' {
+            while self.try_peek() == Some(',') {
                 self.consume_token(",")?;
                 self.consume_whitespace();
                 values.push(self.parse_expression(current_query)?);

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -414,7 +414,7 @@
 //! # Debugging
 //!
 //! To support members of the Ancient and Harmonious Order of Printf Debuggers, you can use `print`
-//! statements to print out the content of any expressions during the execution of a graph DSL
+//! statements to print out (to `stderr`) the content of any expressions during the execution of a graph DSL
 //! file:
 //!
 //! ``` tsg

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -375,3 +375,36 @@ fn can_parse_sets() {
         ]]
     );
 }
+
+#[test]
+fn can_parse_print() {
+    let mut ctx = Context::new();
+    let source = r#"
+        (identifier)
+        {
+          print "x =", 5
+        }    
+    "#;
+    let mut file = File::new(tree_sitter_python::language());
+    file.parse(&mut ctx, source).expect("Cannot parse file");
+
+    let statements = file
+        .stanzas
+        .into_iter()
+        .map(|s| s.statements)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        statements,
+        vec![vec![Print {
+            values: vec![
+                StringConstant {
+                    value: String::from("x =")
+                }
+                .into(),
+                IntegerConstant { value: 5 }.into(),
+            ],
+            location: Location { row: 3, column: 10 },
+        }
+        .into()]]
+    );
+}


### PR DESCRIPTION
We were accidentally consuming the next token whenever `try_next`
returned `Some(x)` where `x != ','`. This obviously caused a lot of
problems further down the line.

To fix this, I changed the code to use `peek` instead.

This made the `try_next` function unused, so to remove the warning I
also added an `#[allow(dead_code)]` (just in case it becomes useful
later on).

---
Also ensures that strings are printed verbatim (and without escaping),
to make the printed output a bit nicer.