### PR TITLE
Update installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ tree-sitter-graph = "0.2"
 To use it as a program, install it via `cargo install`:
 
 ```
-$ cargo install tree-sitter-graph
+$ cargo install --all-features tree-sitter-graph
 ```
 
 Check out our [documentation](https://docs.rs/tree-sitter-graph/) for more

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ tree-sitter-graph = "0.2"
 To use it as a program, install it via `cargo install`:
 
 ```
-$ cargo install --all-features tree-sitter-graph
+$ cargo install --features cli tree-sitter-graph
 ```
 
 Check out our [documentation](https://docs.rs/tree-sitter-graph/) for more


### PR DESCRIPTION
This might be due to holding this incorrectly,  but a recent attempt to install `tree-sitter-graph` resulted in the following error message:

```
error: no binaries are available for install using the selected features
```

Adjusting the installation command to include the `--all-features` flag appears to fix this,  but this may not be the ideal solution.