### PR TITLE
Skip erroneous parse trees

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -59,6 +59,9 @@ impl File {
         globals: &mut Variables,
     ) -> Result<Graph<'tree>, ExecutionError> {
         let mut graph = Graph::new();
+        if tree.root_node().has_error() {
+            return Err(ExecutionError::ParseTreeHasErrors);
+        }
         let mut locals = Variables::new();
         let mut scoped = ScopedVariables::new();
         let mut current_regex_matches = Vec::new();
@@ -118,6 +121,8 @@ pub enum ExecutionError {
     UndefinedEdge(String),
     #[error("Undefined variable {0}")]
     UndefinedVariable(String),
+    #[error("Parse tree has errors")]
+    ParseTreeHasErrors,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
Query evaluation on parse trees with errors can cause problems. Eventually we would like to be able to execute a DSL file as much as possible, but there are several open questions on how to deal with the resulting missing information. For now we simply fail in parse trees with errors to prevent hard crashes.