### PR TITLE
Fix nested scan

### DIFF
--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -357,6 +357,8 @@
 //! earliest matching regular expression in each iteration, until we have exhausted the entire
 //! string, or none of the regular expressions match.
 //!
+//! Note that a regular expression that matches an empty string results in an error.
+//!
 //! Within each regular expression's block, you can use `$0`, `$1`, etc., to refer to any capture
 //! groups in the regular expression.
 //!


### PR DESCRIPTION
The scan statement reuses a vector to store regex captures. This is incorrect if scans are nested, because the inner scan overwrites the captures of the outer scan, even though these might be used in the next iteration of the outer scan. Instead of reusing the vector, a new vector is used, preserving any enclosing captures.