### PR TITLE
Implement block scoping

### DIFF
--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -63,9 +63,9 @@ fn main() -> Result<()> {
     file.parse(&mut ctx, &tsg)
         .with_context(|| anyhow!("Error parsing TSG file {}", tsg_path.display()))?;
     let mut functions = Functions::stdlib(&mut ctx);
-    let mut globals = Variables::new();
+    let globals = Variables::new();
     let graph = file
-        .execute(&ctx, &tree, &source, &mut functions, &mut globals)
+        .execute(&ctx, &tree, &source, &mut functions, &globals)
         .with_context(|| format!("Could not execute TSG file {}", tsg_path.display()))?;
     if !quiet {
         print!("{}", graph.display_with(&ctx));

--- a/src/execution/variables.rs
+++ b/src/execution/variables.rs
@@ -1,0 +1,151 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2021, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use std::collections::HashMap;
+
+use crate::graph::SyntaxNodeRef;
+use crate::graph::Value;
+use crate::Identifier;
+
+/// An environment of named variables
+pub(super) trait Variables {
+    /// Adds a new variable to an environment, returning an error if the variable already
+    /// exists.
+    fn add(&mut self, name: Identifier, value: Value, mutable: bool) -> Result<(), ()>;
+
+    /// Sets the variable, returning an error if it does not exists in this environment.
+    fn set(&mut self, name: Identifier, value: Value) -> Result<(), ()>;
+
+    /// Returns the value of a variable, if it exists in this environment.
+    fn get(&self, name: Identifier) -> Option<&Value>;
+}
+
+/// Global immutable variables
+pub struct Globals<'a>(VariableMap<'a>);
+
+impl<'a> Globals<'a> {
+    pub fn new() -> Self {
+        Self(VariableMap::new())
+    }
+
+    pub fn add(&mut self, name: Identifier, value: Value) -> Result<(), ()> {
+        self.0.add(name, value, false)
+    }
+
+    pub fn get(&self, name: Identifier) -> Option<&Value> {
+        self.0.get(name)
+    }
+
+    pub fn remove(&mut self, name: Identifier) {
+        self.0.remove(name)
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+}
+
+/// A map-like implementation of an environment of named variables
+#[derive(Default)]
+pub(super) struct VariableMap<'a> {
+    parent: Option<&'a mut dyn Variables>,
+    values: Vec<NamedVariable>,
+}
+
+struct NamedVariable {
+    name: Identifier,
+    value: Value,
+    mutable: bool,
+}
+
+impl<'a> VariableMap<'a> {
+    /// Creates a new, empty environment of variables.
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new, empty environment of variables.
+    pub(super) fn new_child(parent: &'a mut dyn Variables) -> Self {
+        Self {
+            parent: Some(parent),
+            values: Vec::default(),
+        }
+    }
+
+    pub(super) fn remove(&mut self, name: Identifier) {
+        if let Ok(index) = self.values.binary_search_by_key(&name, |v| v.name) {
+            self.values.remove(index);
+        }
+    }
+
+    /// Clears this list of variables.
+    pub(super) fn clear(&mut self) {
+        self.values.clear();
+    }
+}
+
+impl Variables for VariableMap<'_> {
+    fn add(&mut self, name: Identifier, value: Value, mutable: bool) -> Result<(), ()> {
+        match self.values.binary_search_by_key(&name, |v| v.name) {
+            Ok(_) => Err(()),
+            Err(index) => {
+                let variable = NamedVariable {
+                    name,
+                    value,
+                    mutable,
+                };
+                self.values.insert(index, variable);
+                Ok(())
+            }
+        }
+    }
+
+    fn set(&mut self, name: Identifier, value: Value) -> Result<(), ()> {
+        match self.values.binary_search_by_key(&name, |v| v.name) {
+            Ok(index) => {
+                let variable = &mut self.values[index];
+                if variable.mutable {
+                    variable.value = value;
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+            Err(_) => self
+                .parent
+                .as_mut()
+                .map(|parent| parent.set(name, value))
+                .unwrap_or(Err(())),
+        }
+    }
+
+    fn get(&self, name: Identifier) -> Option<&Value> {
+        match self.values.binary_search_by_key(&name, |v| v.name) {
+            Ok(index) => Some(&self.values[index].value),
+            Err(_) => self
+                .parent
+                .as_ref()
+                .map(|parent| parent.get(name))
+                .flatten(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct ScopedVariables<'a> {
+    scopes: HashMap<SyntaxNodeRef, VariableMap<'a>>,
+}
+
+impl<'a> ScopedVariables<'a> {
+    pub(super) fn new() -> Self {
+        ScopedVariables::default()
+    }
+
+    pub(super) fn get(&mut self, scope: SyntaxNodeRef) -> &mut VariableMap<'a> {
+        self.scopes.entry(scope).or_default()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod graph;
 mod parser;
 
 pub use execution::ExecutionError;
-pub use execution::Variables;
+pub use execution::Globals as Variables;
 pub use parser::Location;
 pub use parser::ParseError;
 

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -184,6 +184,10 @@
 //! creates an **_immutable variable_**, whose value cannot be changed.  A `var` statement creates
 //! a **_mutable variable_**.  You use a `set` statement to change the value of a mutable variable.
 //!
+//! Local variables are block scoped.  For example, a local variable defined in a `scan` arm is not
+//! visible in other scan arms, or after the `scan` statement.  If you need to persist a value for use
+//! after a block, introduce a mutable variable before the block and assign to it inside the block.
+//!
 //! (All global variables are immutable, and cannot be created by any graph DSL statement; they are
 //! only provided by the external process that executes the graph DSL file.  If you need to create
 //! your own "global" variable from within the graph DSL, create a scoped variable on the root


### PR DESCRIPTION
Variable environments where reused inside blocks for scan arms. This is incorrect, because (a) later ietartions of a block might cause duplicate variable errors for local variables, and (b) variables defined inside the block persist after it. This is fixed by creating a hierarchy of environments, where environments delegate to their parent for unknown variables.