### PR TITLE
Use capture quantifiers to create correct capture values

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,6 +9,7 @@
 
 use regex::Regex;
 use std::fmt;
+use tree_sitter::CaptureQuantifier;
 use tree_sitter::Language;
 use tree_sitter::Query;
 
@@ -478,6 +479,8 @@ impl DisplayWithContext for Call {
 pub struct Capture {
     /// The index of this capture in the block's tree-sitter query
     pub index: usize,
+    /// The suffix of the capture
+    pub quantifier: CaptureQuantifier,
     /// The name of the capture
     pub name: Identifier,
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -9,6 +9,7 @@ mod variables;
 
 use anyhow::Context as ErrorContext;
 use thiserror::Error;
+use tree_sitter::CaptureQuantifier;
 use tree_sitter::QueryCursor;
 use tree_sitter::QueryMatch;
 use tree_sitter::Tree;
@@ -482,16 +483,12 @@ impl SetComprehension {
 
 impl Capture {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
-        for capture in exec.mat.captures {
-            if capture.index as usize == self.index {
-                let syntax_node = exec.graph.add_syntax_node(capture.node);
-                return Ok(Value::SyntaxNode(syntax_node));
-            }
-        }
-        Err(ExecutionError::UndefinedCapture(format!(
-            "{}",
-            self.display_with(exec.ctx)
-        )))
+        Ok(query_capture_value(
+            self.index,
+            self.quantifier,
+            exec.mat,
+            exec.graph,
+        ))
     }
 }
 
@@ -667,5 +664,39 @@ impl UnscopedVariable {
                 ExecutionError::UndefinedVariable(format!("{}", self.display_with(exec.ctx)))
             }
         })
+    }
+}
+
+/// Get the value for the given capture, considering the suffix
+pub fn query_capture_value<'tree>(
+    index: usize,
+    quantifier: CaptureQuantifier,
+    mat: &QueryMatch<'_, 'tree>,
+    graph: &mut Graph<'tree>,
+) -> Value {
+    let mut nodes = mat
+        .captures
+        .iter()
+        .filter(|c| c.index as usize == index)
+        .map(|c| c.node);
+    match quantifier {
+        CaptureQuantifier::Zero => panic!("Capture with quantifier 0 has no value"),
+        CaptureQuantifier::One => {
+            let syntax_node = graph.add_syntax_node(nodes.next().unwrap());
+            syntax_node.into()
+        }
+        CaptureQuantifier::ZeroOrMore | CaptureQuantifier::OneOrMore => {
+            let syntax_nodes = nodes
+                .map(|n| graph.add_syntax_node(n.clone()).into())
+                .collect::<Vec<Value>>();
+            syntax_nodes.into()
+        }
+        CaptureQuantifier::ZeroOrOne => match nodes.next() {
+            None => Value::Null.into(),
+            Some(node) => {
+                let syntax_node = graph.add_syntax_node(node);
+                syntax_node.into()
+            }
+        },
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -609,8 +609,14 @@ impl Parser<'_> {
                 ))
             }
         };
+        let quantifier = current_query.capture_quantifiers(0)[index];
         let name = self.ctx.add_identifier(&self.source[start..end]);
-        Ok(ast::Capture { index, name }.into())
+        Ok(ast::Capture {
+            index,
+            quantifier,
+            name,
+        }
+        .into())
     }
 
     fn parse_integer_constant(&mut self) -> Result<ast::Expression, ParseError> {

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -77,6 +77,12 @@
 //! [query]: https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries
 //! [captures]: https://tree-sitter.github.io/tree-sitter/using-parsers#capturing-nodes
 //!
+//! Query patterns can be suffixed by quantification operators. If a pattern with a quantification
+//! suffix is captured, the suffix determines the capture value. In the case of `?`, the capture value
+//! is a null value, or a syntax node. In the case of `+` and `*`, the value is a list of syntax nodes.
+//!
+//! [quantification]: https://tree-sitter.github.io/tree-sitter/using-parsers#quantification-operators
+//!
 //! Comments start with a semicolon, and extend to the end of the line.
 //!
 //! Identifiers start with either an ASCII letter or underscore, and all remaining characters are

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -308,3 +308,80 @@ fn cannot_use_nullable_regex() {
         "#},
     );
 }
+
+#[test]
+fn can_create_present_optional_capture() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (_)? @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: [syntax node pass_statement (1, 1)]
+        "#},
+    );
+}
+
+#[test]
+fn can_create_missing_optional_capture() {
+    check_execution(
+        indoc! {r#"
+        "#},
+        indoc! {r#"
+          (module (_)? @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: #null
+        "#},
+    );
+}
+
+#[test]
+fn can_create_empty_list_capture() {
+    check_execution(
+        indoc! {r#"
+        "#},
+        indoc! {r#"
+          (module (_)* @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: []
+        "#},
+    );
+}
+
+#[test]
+fn can_create_nonempty_list_capture() {
+    check_execution(
+        indoc! {r#"
+          pass
+          pass
+        "#},
+        indoc! {r#"
+          (module (_)+ @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: [[syntax node pass_statement (1, 1)], [syntax node pass_statement (2, 1)]]
+        "#},
+    );
+}


### PR DESCRIPTION
Captures do not consider the effective quantifier of the capture in the query
when constructing a value. However, depending on the qunatifier, an optional
value, or a list must be constructed.

Depends on:

- [x] https://github.com/tree-sitter/tree-sitter/pull/1504
- [x] A release including that PR
- [x] Updated dependencies in `Cargo.toml` to said release
