### PR TITLE
Add value conversions

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -212,7 +212,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 let parent = match node.parent() {
                     Some(parent) => parent,
@@ -223,7 +223,7 @@ pub mod stdlib {
                 let mut tree_cursor = parent.walk();
                 let index = parent
                     .named_children(&mut tree_cursor)
-                    .position(|child| child == *node)
+                    .position(|child| child == node)
                     .ok_or(anyhow!("Called named-child-index on a non-named child"))?;
                 Ok(Value::Integer(index as u32))
             }
@@ -240,7 +240,7 @@ pub mod stdlib {
                 source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 Ok(Value::String(source[node.byte_range()].to_string()))
             }
@@ -257,7 +257,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.start_position().row as u32))
             }
@@ -275,7 +275,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.start_position().column as u32))
             }
@@ -292,7 +292,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.end_position().row as u32))
             }
@@ -309,7 +309,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.end_position().column as u32))
             }
@@ -326,7 +326,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 Ok(Value::String(node.kind().to_string()))
             }
@@ -344,7 +344,7 @@ pub mod stdlib {
                 _source: &str,
                 parameters: &mut dyn Parameters,
             ) -> Result<Value, ExecutionError> {
-                let node = parameters.param()?.into_syntax_node(graph)?;
+                let node = graph[parameters.param()?.into_syntax_node_ref(graph)?];
                 parameters.finish()?;
                 Ok(Value::Integer(node.named_child_count() as u32))
             }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -459,17 +459,27 @@ impl Value {
 
     /// Coerces this value into a syntax node reference, returning an error if it's some other type
     /// of value.
-    pub fn into_syntax_node<'a, 'tree>(
+    pub fn into_syntax_node_ref<'a, 'tree>(
         self,
         graph: &'a Graph<'tree>,
-    ) -> Result<&'a Node<'tree>, ExecutionError> {
+    ) -> Result<SyntaxNodeRef, ExecutionError> {
         match self {
-            Value::SyntaxNode(node) => Ok(&graph[node]),
+            Value::SyntaxNode(node) => Ok(node),
             _ => Err(ExecutionError::ExpectedSyntaxNode(format!(
                 "got {}",
                 self.display_with(graph)
             ))),
         }
+    }
+
+    /// Coerces this value into a syntax node, returning an error if it's some other type
+    /// of value.
+    #[deprecated(note = "Use the pattern graph[value.into_syntax_node_ref(graph)] instead")]
+    pub fn into_syntax_node<'a, 'tree>(
+        self,
+        graph: &'a Graph<'tree>,
+    ) -> Result<&'a Node<'tree>, ExecutionError> {
+        Ok(&graph[self.into_syntax_node_ref(graph)?])
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -424,6 +424,16 @@ impl Value {
         }
     }
 
+    pub fn as_bool(&self, graph: &Graph) -> Result<bool, ExecutionError> {
+        match self {
+            Value::Boolean(value) => Ok(*value),
+            _ => Err(ExecutionError::ExpectedBoolean(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
+    }
+
     /// Coerces this value into an integer, returning an error if it's some other type of value.
     pub fn into_integer(self, graph: &Graph) -> Result<u32, ExecutionError> {
         match self {
@@ -435,8 +445,28 @@ impl Value {
         }
     }
 
+    pub fn as_integer(&self, graph: &Graph) -> Result<u32, ExecutionError> {
+        match self {
+            Value::Integer(value) => Ok(*value),
+            _ => Err(ExecutionError::ExpectedInteger(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
+    }
+
     /// Coerces this value into a string, returning an error if it's some other type of value.
     pub fn into_string(self, graph: &Graph) -> Result<String, ExecutionError> {
+        match self {
+            Value::String(value) => Ok(value),
+            _ => Err(ExecutionError::ExpectedString(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
+    }
+
+    pub fn as_string(&self, graph: &Graph) -> Result<&str, ExecutionError> {
         match self {
             Value::String(value) => Ok(value),
             _ => Err(ExecutionError::ExpectedString(format!(
@@ -457,6 +487,16 @@ impl Value {
         }
     }
 
+    pub fn as_list(&self, graph: &Graph) -> Result<&Vec<Value>, ExecutionError> {
+        match self {
+            Value::List(values) => Ok(values),
+            _ => Err(ExecutionError::ExpectedList(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
+    }
+
     /// Coerces this value into a graph node reference, returning an error if it's some other type
     /// of value.
     pub fn into_graph_node_ref<'a, 'tree>(
@@ -465,6 +505,19 @@ impl Value {
     ) -> Result<GraphNodeRef, ExecutionError> {
         match self {
             Value::GraphNode(node) => Ok(node),
+            _ => Err(ExecutionError::ExpectedGraphNode(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
+    }
+
+    pub fn as_graph_node_ref<'a, 'tree>(
+        &self,
+        graph: &'a Graph<'tree>,
+    ) -> Result<GraphNodeRef, ExecutionError> {
+        match self {
+            Value::GraphNode(node) => Ok(*node),
             _ => Err(ExecutionError::ExpectedGraphNode(format!(
                 "got {}",
                 self.display_with(graph)
@@ -495,6 +548,19 @@ impl Value {
         graph: &'a Graph<'tree>,
     ) -> Result<&'a Node<'tree>, ExecutionError> {
         Ok(&graph[self.into_syntax_node_ref(graph)?])
+    }
+
+    pub fn as_syntax_node_ref<'a, 'tree>(
+        &self,
+        graph: &'a Graph<'tree>,
+    ) -> Result<SyntaxNodeRef, ExecutionError> {
+        match self {
+            Value::SyntaxNode(node) => Ok(*node),
+            _ => Err(ExecutionError::ExpectedSyntaxNode(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -457,6 +457,21 @@ impl Value {
         }
     }
 
+    /// Coerces this value into a graph node reference, returning an error if it's some other type
+    /// of value.
+    pub fn into_graph_node_ref<'a, 'tree>(
+        self,
+        graph: &'a Graph<'tree>,
+    ) -> Result<GraphNodeRef, ExecutionError> {
+        match self {
+            Value::GraphNode(node) => Ok(node),
+            _ => Err(ExecutionError::ExpectedGraphNode(format!(
+                "got {}",
+                self.display_with(graph)
+            ))),
+        }
+    }
+
     /// Coerces this value into a syntax node reference, returning an error if it's some other type
     /// of value.
     pub fn into_syntax_node_ref<'a, 'tree>(


### PR DESCRIPTION
This adds:
- two owned `into_*` value conversions for graph and syntax references, and
- borrowed `as_*` conversions as an alternative to the owned conversions, which sometimes force unnecessary clones.