### PR TITLE
Lazy evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ test = false
 
 [dependencies]
 anyhow = "1.0"
+log = "0.4"
 regex = "1"
 smallvec = { version="1.6", features=["union"] }
 thiserror = "1.0"
@@ -30,6 +31,7 @@ default-features = false
 features = ["std", "inline-more", "backends"]
 
 [dev-dependencies]
+env_logger = "0.9"
 indoc = "1.0"
 tree-sitter-python = "0.19.1"
 
@@ -40,11 +42,15 @@ name = "tree-sitter-graph"
 required-features = ["cli"]
 
 [features]
-cli = ["clap", "tree-sitter-config", "tree-sitter-loader"]
+cli = ["clap", "env_logger", "tree-sitter-config", "tree-sitter-loader"]
 
 [dependencies.clap]
 optional = true
 version = "2.32"
+
+[dependencies.env_logger]
+optional = true
+version = "0.9"
 
 [dependencies.tree-sitter-config]
 optional = true

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -35,6 +35,12 @@ fn main() -> Result<()> {
                 .long("quiet")
                 .help("Suppress console output"),
         )
+        .arg(
+            Arg::with_name("lazy")
+                .short("z")
+                .long("lazy")
+                .help("Use lazy evaluation (experimental)"),
+        )
         .arg(Arg::with_name("scope").long("scope").takes_value(true))
         .arg(Arg::with_name("json").long("json").takes_value(false))
         .get_matches();
@@ -43,6 +49,7 @@ fn main() -> Result<()> {
     let source_path = Path::new(matches.value_of("source").unwrap());
     let current_dir = std::env::current_dir().unwrap();
     let quiet = matches.is_present("quiet");
+    let lazy = matches.is_present("lazy");
     let config = Config::load()?;
     let mut loader = Loader::new()?;
     let loader_config = config.get()?;
@@ -65,9 +72,12 @@ fn main() -> Result<()> {
         .with_context(|| anyhow!("Error parsing TSG file {}", tsg_path.display()))?;
     let mut functions = Functions::stdlib(&mut ctx);
     let globals = Variables::new();
-    let graph = file
-        .execute(&ctx, &tree, &source, &mut functions, &globals)
-        .with_context(|| format!("Could not execute TSG file {}", tsg_path.display()))?;
+    let graph = if lazy {
+        file.execute_lazy(&mut ctx, &tree, &source, &mut functions, &globals)
+    } else {
+        file.execute(&mut ctx, &tree, &source, &mut functions, &globals)
+    }
+    .with_context(|| anyhow!("Could not execute TSG file {}", tsg_path.display()))?;
     let json = matches.is_present("json");
     if json {
         graph.display_json(&ctx);

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -23,6 +23,8 @@ use tree_sitter_loader::Loader;
 const BUILD_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 fn main() -> Result<()> {
+    init_log();
+
     let matches = App::new("tree-sitter-graph")
         .version(BUILD_VERSION)
         .author("Douglas Creager <dcreager@dcreager.net>")
@@ -85,4 +87,12 @@ fn main() -> Result<()> {
         print!("{}", graph.display_with(&ctx));
     }
     Ok(())
+}
+
+fn init_log() {
+    let _ = env_logger::builder()
+        .format_level(false)
+        .format_target(false)
+        .format_timestamp(None)
+        .init();
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -116,6 +116,10 @@ impl File {
 pub enum ExecutionError {
     #[error("Cannot assign immutable variable {0}")]
     CannotAssignImmutableVariable(String),
+    #[error("Cannot assign scoped variable {0}")]
+    CannotAssignScopedVariable(String),
+    #[error("Cannot define mutable scoped variable {0}")]
+    CannotDefineMutableScopedVariable(String),
     #[error("Duplicate attribute {0}")]
     DuplicateAttribute(String),
     #[error("Duplicate edge {0}")]

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -138,18 +138,26 @@ pub enum ExecutionError {
     InvalidParameters(String),
     #[error("Scoped variables can only be attached to syntax nodes {0}")]
     InvalidVariableScope(String),
+    #[error("Recursively defined scoped variable {0}")]
+    RecursivelyDefinedScopedVariable(String),
+    #[error("Recursively defined variable {0}")]
+    RecursivelyDefinedVariable(String),
     #[error("Undefined capture {0}")]
     UndefinedCapture(String),
     #[error("Undefined function {0}")]
     UndefinedFunction(String),
     #[error("Undefined regex capture {0}")]
     UndefinedRegexCapture(String),
+    #[error("Undefined scoped variable {0}")]
+    UndefinedScopedVariable(String),
     #[error("Empty regex capture {0}")]
     EmptyRegexCapture(String),
     #[error("Undefined edge {0}")]
     UndefinedEdge(String),
     #[error("Undefined variable {0}")]
     UndefinedVariable(String),
+    #[error("Cannot add scoped variable after being forced {0}")]
+    VariableScopesAlreadyForced(String),
     #[error("Parse tree has errors")]
     ParseTreeHasErrors,
     #[error(transparent)]

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -5,13 +5,24 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+mod store;
+mod values;
+
+use std::collections::HashMap;
+use std::fmt;
+
+use tree_sitter::Tree;
+
 use crate::ast;
 use crate::execution::ExecutionError;
 use crate::execution::Globals;
 use crate::functions::Functions;
+use crate::graph;
 use crate::graph::Graph;
 use crate::Context;
-use tree_sitter::Tree;
+use crate::Identifier;
+
+use store::*;
 
 impl ast::File {
     /// Executes this graph DSL file against a source file.  You must provide the parsed syntax
@@ -30,5 +41,64 @@ impl ast::File {
             return Err(ExecutionError::ParseTreeHasErrors);
         }
         Ok(graph)
+    }
+}
+
+/// Context for evaluation, which evalautes the lazy graph to build the actual graph
+pub(self) struct EvaluationContext<'a, 'tree> {
+    pub ctx: &'a Context,
+    pub source: &'tree str,
+    pub graph: &'a mut Graph<'tree>,
+    pub functions: &'a mut Functions,
+    pub store: &'a Store,
+    pub scoped_store: &'a ScopedVariables,
+    pub function_parameters: &'a mut Vec<graph::Value>, // re-usable buffer to reduce memory allocations
+    pub prev_element_debug_info: &'a mut HashMap<GraphElementKey, DebugInfo>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(super) enum GraphElementKey {
+    NodeAttribute(graph::GraphNodeRef, Identifier),
+    Edge(graph::GraphNodeRef, graph::GraphNodeRef),
+    EdgeAttribute(graph::GraphNodeRef, graph::GraphNodeRef, Identifier),
+}
+
+/// Trait to Display with a given Context and Graph
+pub trait DisplayWithContextAndGraph
+where
+    Self: Sized,
+{
+    fn fmt<'tree>(
+        &self,
+        f: &mut fmt::Formatter,
+        ctx: &Context,
+        graph: &Graph<'tree>,
+    ) -> fmt::Result;
+
+    fn display_with<'a, 'tree>(
+        &'a self,
+        ctx: &'a Context,
+        graph: &'a Graph<'tree>,
+    ) -> Box<dyn fmt::Display + 'a> {
+        struct Impl<'a, 'tree, T: DisplayWithContextAndGraph>(&'a T, &'a Context, &'a Graph<'tree>);
+
+        impl<'a, 'tree, T: DisplayWithContextAndGraph> fmt::Display for Impl<'a, 'tree, T> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                self.0.fmt(f, self.1, self.2)
+            }
+        }
+
+        Box::new(Impl(self, ctx, graph))
+    }
+}
+
+impl<T: DisplayWithContextAndGraph> DisplayWithContextAndGraph for Box<T> {
+    fn fmt<'tree>(
+        &self,
+        f: &mut fmt::Formatter,
+        ctx: &Context,
+        graph: &Graph<'tree>,
+    ) -> fmt::Result {
+        self.as_ref().fmt(f, ctx, graph)
     }
 }

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -1,0 +1,34 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use crate::ast;
+use crate::execution::ExecutionError;
+use crate::execution::Globals;
+use crate::functions::Functions;
+use crate::graph::Graph;
+use crate::Context;
+use tree_sitter::Tree;
+
+impl ast::File {
+    /// Executes this graph DSL file against a source file.  You must provide the parsed syntax
+    /// tree (`tree`) as well as the source text that it was parsed from (`source`).  You also
+    /// provide the set of functions and global variables that are available during execution.
+    pub fn execute_lazy<'tree>(
+        &self,
+        _ctx: &Context,
+        tree: &'tree Tree,
+        _source: &'tree str,
+        _functions: &mut Functions,
+        _globals: &Globals,
+    ) -> Result<Graph<'tree>, ExecutionError> {
+        let graph = Graph::new();
+        if tree.root_node().has_error() {
+            return Err(ExecutionError::ParseTreeHasErrors);
+        }
+        Ok(graph)
+    }
+}

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -7,6 +7,7 @@
 
 mod store;
 mod values;
+mod variables;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -25,6 +26,8 @@ use crate::Context;
 use crate::Identifier;
 
 use store::*;
+use values::*;
+use variables::*;
 
 impl ast::File {
     /// Executes this graph DSL file against a source file.  You must provide the parsed syntax

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -11,6 +11,7 @@ mod values;
 use std::collections::HashMap;
 use std::fmt;
 
+use tree_sitter::Query;
 use tree_sitter::Tree;
 
 use crate::ast;
@@ -19,6 +20,7 @@ use crate::execution::Globals;
 use crate::functions::Functions;
 use crate::graph;
 use crate::graph::Graph;
+use crate::parser::FULL_MATCH;
 use crate::Context;
 use crate::Identifier;
 
@@ -61,6 +63,15 @@ pub(super) enum GraphElementKey {
     NodeAttribute(graph::GraphNodeRef, Identifier),
     Edge(graph::GraphNodeRef, graph::GraphNodeRef),
     EdgeAttribute(graph::GraphNodeRef, graph::GraphNodeRef, Identifier),
+}
+
+#[allow(unused)]
+fn full_match_capture_index(query: &Query) -> usize {
+    query
+        .capture_names()
+        .iter()
+        .position(|c| c == FULL_MATCH)
+        .unwrap()
 }
 
 /// Trait to Display with a given Context and Graph

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -53,6 +53,24 @@ impl ast::File {
         globals: &Globals,
     ) -> Result<Graph<'tree>, ExecutionError> {
         let mut graph = Graph::new();
+        self.execute_lazy_into(ctx, &mut graph, tree, source, functions, globals)?;
+        Ok(graph)
+    }
+
+    /// Executes this graph DSL file against a source file, saving the results into an existing
+    /// `Graph` instance.  You must provide the parsed syntax tree (`tree`) as well as the source
+    /// text that it was parsed from (`source`).  You also provide the set of functions and global
+    /// variables that are available during execution. This variant is useful when you need to
+    /// “pre-seed” the graph with some predefined nodes and/or edges before executing the DSL file.
+    pub fn execute_lazy_into<'tree>(
+        &self,
+        ctx: &Context,
+        graph: &mut Graph<'tree>,
+        tree: &'tree Tree,
+        source: &'tree str,
+        functions: &mut Functions,
+        globals: &Globals,
+    ) -> Result<(), ExecutionError> {
         if tree.root_node().has_error() {
             return Err(ExecutionError::ParseTreeHasErrors);
         }
@@ -66,7 +84,7 @@ impl ast::File {
                 ctx,
                 tree,
                 source,
-                &mut graph,
+                graph,
                 globals,
                 &mut locals,
                 &mut cursor,
@@ -82,7 +100,7 @@ impl ast::File {
                 .evaluate(&mut EvaluationContext {
                     ctx,
                     source,
-                    graph: &mut graph,
+                    graph,
                     functions,
                     store: &mut store,
                     scoped_store: &mut scoped_store,
@@ -91,7 +109,7 @@ impl ast::File {
                 })
                 .with_context(|| format!("Executing {}", graph_stmt.display_with(ctx, &graph)))?;
         }
-        Ok(graph)
+        Ok(())
     }
 }
 

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+mod statements;
 mod store;
 mod values;
 mod variables;
@@ -25,6 +26,7 @@ use crate::parser::FULL_MATCH;
 use crate::Context;
 use crate::Identifier;
 
+use statements::*;
 use store::*;
 use values::*;
 use variables::*;

--- a/src/lazy_execution/statements.rs
+++ b/src/lazy_execution/statements.rs
@@ -1,0 +1,46 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines graph statements for lazy DSL evaluation
+
+use log::{debug, trace};
+
+use std::convert::From;
+use std::fmt;
+
+use crate::execution::ExecutionError;
+use crate::graph::DisplayWithGraph;
+use crate::graph::Graph;
+use crate::Context;
+use crate::DisplayWithContext as _;
+use crate::Identifier;
+
+use super::store::DebugInfo;
+use super::values::*;
+use super::DisplayWithContextAndGraph;
+use super::EvaluationContext;
+use super::GraphElementKey;
+
+/// Lazy graph statements
+#[derive(Debug)]
+pub enum Statement {}
+
+impl Statement {
+    pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
+        debug!("eval {}", self.display_with(exec.ctx, exec.graph));
+        trace!("{{");
+        let result = Ok(());
+        trace!("}}");
+        result
+    }
+}
+
+impl DisplayWithContextAndGraph for Statement {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        Ok(())
+    }
+}

--- a/src/lazy_execution/statements.rs
+++ b/src/lazy_execution/statements.rs
@@ -27,78 +27,78 @@ use super::GraphElementKey;
 
 /// Lazy graph statements
 #[derive(Debug)]
-pub enum Statement {
-    AddGraphNodeAttribute(AddGraphNodeAttribute),
-    CreateEdge(CreateEdge),
-    AddEdgeAttribute(AddEdgeAttribute),
-    Print(Print),
+pub(super) enum LazyStatement {
+    AddGraphNodeAttribute(LazyAddGraphNodeAttribute),
+    CreateEdge(LazyCreateEdge),
+    AddEdgeAttribute(LazyAddEdgeAttribute),
+    Print(LazyPrint),
 }
 
-impl Statement {
+impl LazyStatement {
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
         debug!("eval {}", self.display_with(exec.ctx, exec.graph));
         trace!("{{");
         let result = match self {
-            Statement::AddGraphNodeAttribute(stmt) => stmt.evaluate(exec),
-            Statement::CreateEdge(stmt) => stmt.evaluate(exec),
-            Statement::AddEdgeAttribute(stmt) => stmt.evaluate(exec),
-            Statement::Print(stmt) => stmt.evaluate(exec),
+            Self::AddGraphNodeAttribute(stmt) => stmt.evaluate(exec),
+            Self::CreateEdge(stmt) => stmt.evaluate(exec),
+            Self::AddEdgeAttribute(stmt) => stmt.evaluate(exec),
+            Self::Print(stmt) => stmt.evaluate(exec),
         };
         trace!("}}");
         result
     }
 }
 
-impl From<AddEdgeAttribute> for Statement {
-    fn from(stmt: AddEdgeAttribute) -> Self {
-        Statement::AddEdgeAttribute(stmt)
+impl From<LazyAddEdgeAttribute> for LazyStatement {
+    fn from(stmt: LazyAddEdgeAttribute) -> Self {
+        Self::AddEdgeAttribute(stmt)
     }
 }
 
-impl From<AddGraphNodeAttribute> for Statement {
-    fn from(stmt: AddGraphNodeAttribute) -> Self {
-        Statement::AddGraphNodeAttribute(stmt)
+impl From<LazyAddGraphNodeAttribute> for LazyStatement {
+    fn from(stmt: LazyAddGraphNodeAttribute) -> Self {
+        Self::AddGraphNodeAttribute(stmt)
     }
 }
 
-impl From<CreateEdge> for Statement {
-    fn from(stmt: CreateEdge) -> Self {
-        Statement::CreateEdge(stmt)
+impl From<LazyCreateEdge> for LazyStatement {
+    fn from(stmt: LazyCreateEdge) -> Self {
+        Self::CreateEdge(stmt)
     }
 }
 
-impl From<Print> for Statement {
-    fn from(stmt: Print) -> Self {
-        Statement::Print(stmt)
+impl From<LazyPrint> for LazyStatement {
+    fn from(stmt: LazyPrint) -> Self {
+        Self::Print(stmt)
     }
 }
 
-impl DisplayWithContextAndGraph for Statement {
+impl DisplayWithContextAndGraph for LazyStatement {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
         match self {
-            Statement::AddGraphNodeAttribute(stmt) => stmt.fmt(f, ctx, graph),
-            Statement::CreateEdge(stmt) => stmt.fmt(f, ctx, graph),
-            Statement::AddEdgeAttribute(stmt) => stmt.fmt(f, ctx, graph),
-            Statement::Print(stmt) => stmt.fmt(f, ctx, graph),
+            Self::AddGraphNodeAttribute(stmt) => stmt.fmt(f, ctx, graph),
+            Self::CreateEdge(stmt) => stmt.fmt(f, ctx, graph),
+            Self::AddEdgeAttribute(stmt) => stmt.fmt(f, ctx, graph),
+            Self::Print(stmt) => stmt.fmt(f, ctx, graph),
         }
     }
 }
 
 /// Lazy statement to add graph node attributes
 #[derive(Debug)]
-pub struct AddGraphNodeAttribute {
-    node: Value,
-    attributes: Vec<Attribute>,
+pub(super) struct LazyAddGraphNodeAttribute {
+    node: LazyValue,
+    attributes: Vec<LazyAttribute>,
     debug_info: DebugInfo,
 }
 
-impl AddGraphNodeAttribute {
-    pub fn new(
-        node: Value,
-        attributes: Vec<Attribute>,
+impl LazyAddGraphNodeAttribute {
+    pub(super) fn new(
+        node: LazyValue,
+        attributes: Vec<LazyAttribute>,
         debug_info: DebugInfo,
-    ) -> AddGraphNodeAttribute {
-        AddGraphNodeAttribute {
+    ) -> Self {
+        Self {
             node,
             attributes,
             debug_info,
@@ -130,7 +130,7 @@ impl AddGraphNodeAttribute {
     }
 }
 
-impl DisplayWithContextAndGraph for AddGraphNodeAttribute {
+impl DisplayWithContextAndGraph for LazyAddGraphNodeAttribute {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
         write!(f, "attr ({})", self.node.display_with(ctx, graph))?;
         for attr in &self.attributes {
@@ -142,15 +142,15 @@ impl DisplayWithContextAndGraph for AddGraphNodeAttribute {
 
 /// Lazy statement to create a graph edge
 #[derive(Debug)]
-pub struct CreateEdge {
-    source: Value,
-    sink: Value,
+pub(super) struct LazyCreateEdge {
+    source: LazyValue,
+    sink: LazyValue,
     debug_info: DebugInfo,
 }
 
-impl CreateEdge {
-    pub fn new(source: Value, sink: Value, debug_info: DebugInfo) -> CreateEdge {
-        CreateEdge {
+impl LazyCreateEdge {
+    pub(super) fn new(source: LazyValue, sink: LazyValue, debug_info: DebugInfo) -> Self {
+        Self {
             source,
             sink,
             debug_info,
@@ -176,7 +176,7 @@ impl CreateEdge {
     }
 }
 
-impl DisplayWithContextAndGraph for CreateEdge {
+impl DisplayWithContextAndGraph for LazyCreateEdge {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
         write!(
             f,
@@ -190,21 +190,21 @@ impl DisplayWithContextAndGraph for CreateEdge {
 
 /// Lazy statement to add graph edge attributes
 #[derive(Debug)]
-pub struct AddEdgeAttribute {
-    source: Value,
-    sink: Value,
-    attributes: Vec<Attribute>,
+pub(super) struct LazyAddEdgeAttribute {
+    source: LazyValue,
+    sink: LazyValue,
+    attributes: Vec<LazyAttribute>,
     debug_info: DebugInfo,
 }
 
-impl AddEdgeAttribute {
-    pub fn new(
-        source: Value,
-        sink: Value,
-        attributes: Vec<Attribute>,
+impl LazyAddEdgeAttribute {
+    pub(super) fn new(
+        source: LazyValue,
+        sink: LazyValue,
+        attributes: Vec<LazyAttribute>,
         debug_info: DebugInfo,
-    ) -> AddEdgeAttribute {
-        AddEdgeAttribute {
+    ) -> Self {
+        Self {
             source,
             sink,
             attributes,
@@ -245,7 +245,7 @@ impl AddEdgeAttribute {
     }
 }
 
-impl DisplayWithContextAndGraph for AddEdgeAttribute {
+impl DisplayWithContextAndGraph for LazyAddEdgeAttribute {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
         write!(
             f,
@@ -262,20 +262,20 @@ impl DisplayWithContextAndGraph for AddEdgeAttribute {
 
 /// Lazy statement to print values
 #[derive(Debug)]
-pub struct Print {
-    arguments: Vec<PrintArgument>,
+pub(super) struct LazyPrint {
+    arguments: Vec<LazyPrintArgument>,
     debug_info: DebugInfo,
 }
 
 #[derive(Debug)]
-pub enum PrintArgument {
+pub(super) enum LazyPrintArgument {
     Text(String),
-    Value(Value),
+    Value(LazyValue),
 }
 
-impl Print {
-    pub fn new(arguments: Vec<PrintArgument>, debug_info: DebugInfo) -> Print {
-        Print {
+impl LazyPrint {
+    pub(super) fn new(arguments: Vec<LazyPrintArgument>, debug_info: DebugInfo) -> Self {
+        Self {
             arguments,
             debug_info,
         }
@@ -284,8 +284,8 @@ impl Print {
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
         for argument in &self.arguments {
             match argument {
-                PrintArgument::Text(string) => eprint!("{}", string),
-                PrintArgument::Value(value) => {
+                LazyPrintArgument::Text(string) => eprint!("{}", string),
+                LazyPrintArgument::Value(value) => {
                     let value = value.evaluate(exec)?;
                     eprint!("{}", value.display_with(exec.graph));
                 }
@@ -296,7 +296,7 @@ impl Print {
     }
 }
 
-impl DisplayWithContextAndGraph for Print {
+impl DisplayWithContextAndGraph for LazyPrint {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
         write!(f, "print")?;
         let mut first = true;
@@ -307,8 +307,8 @@ impl DisplayWithContextAndGraph for Print {
                 write!(f, ", ")?;
             }
             match argument {
-                PrintArgument::Text(string) => write!(f, "\"{}\"", string)?,
-                PrintArgument::Value(value) => write!(f, "{}", value.display_with(ctx, graph))?,
+                LazyPrintArgument::Text(string) => write!(f, "\"{}\"", string)?,
+                LazyPrintArgument::Value(value) => write!(f, "{}", value.display_with(ctx, graph))?,
             };
         }
         write!(f, " at {}", self.debug_info)
@@ -317,18 +317,18 @@ impl DisplayWithContextAndGraph for Print {
 
 /// Lazy attribute
 #[derive(Debug)]
-pub struct Attribute {
+pub(super) struct LazyAttribute {
     name: Identifier,
-    value: Value,
+    value: LazyValue,
 }
 
-impl Attribute {
-    pub fn new(name: Identifier, value: Value) -> Attribute {
-        Attribute { name, value }
+impl LazyAttribute {
+    pub(super) fn new(name: Identifier, value: LazyValue) -> Self {
+        Self { name, value }
     }
 }
 
-impl DisplayWithContextAndGraph for Attribute {
+impl DisplayWithContextAndGraph for LazyAttribute {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
         write!(
             f,

--- a/src/lazy_execution/statements.rs
+++ b/src/lazy_execution/statements.rs
@@ -27,20 +27,250 @@ use super::GraphElementKey;
 
 /// Lazy graph statements
 #[derive(Debug)]
-pub enum Statement {}
+pub enum Statement {
+    AddGraphNodeAttribute(AddGraphNodeAttribute),
+    CreateEdge(CreateEdge),
+    AddEdgeAttribute(AddEdgeAttribute),
+}
 
 impl Statement {
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
         debug!("eval {}", self.display_with(exec.ctx, exec.graph));
         trace!("{{");
-        let result = Ok(());
+        let result = match self {
+            Statement::AddGraphNodeAttribute(stmt) => stmt.evaluate(exec),
+            Statement::CreateEdge(stmt) => stmt.evaluate(exec),
+            Statement::AddEdgeAttribute(stmt) => stmt.evaluate(exec),
+        };
         trace!("}}");
         result
     }
 }
 
+impl From<AddEdgeAttribute> for Statement {
+    fn from(stmt: AddEdgeAttribute) -> Self {
+        Statement::AddEdgeAttribute(stmt)
+    }
+}
+
+impl From<AddGraphNodeAttribute> for Statement {
+    fn from(stmt: AddGraphNodeAttribute) -> Self {
+        Statement::AddGraphNodeAttribute(stmt)
+    }
+}
+
+impl From<CreateEdge> for Statement {
+    fn from(stmt: CreateEdge) -> Self {
+        Statement::CreateEdge(stmt)
+    }
+}
+
 impl DisplayWithContextAndGraph for Statement {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        match self {
+            Statement::AddGraphNodeAttribute(stmt) => stmt.fmt(f, ctx, graph),
+            Statement::CreateEdge(stmt) => stmt.fmt(f, ctx, graph),
+            Statement::AddEdgeAttribute(stmt) => stmt.fmt(f, ctx, graph),
+        }
+    }
+}
+
+/// Lazy statement to add graph node attributes
+#[derive(Debug)]
+pub struct AddGraphNodeAttribute {
+    node: Value,
+    attributes: Vec<Attribute>,
+    debug_info: DebugInfo,
+}
+
+impl AddGraphNodeAttribute {
+    pub fn new(
+        node: Value,
+        attributes: Vec<Attribute>,
+        debug_info: DebugInfo,
+    ) -> AddGraphNodeAttribute {
+        AddGraphNodeAttribute {
+            node,
+            attributes,
+            debug_info,
+        }
+    }
+
+    pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
+        let node = self.node.evaluate_as_graph_node(exec)?;
+        for attribute in &self.attributes {
+            let value = attribute.value.evaluate(exec)?;
+            let prev_debug_info = exec.prev_element_debug_info.insert(
+                GraphElementKey::NodeAttribute(node, attribute.name),
+                self.debug_info,
+            );
+            exec.graph[node]
+                .attributes
+                .add(attribute.name, value)
+                .map_err(|_| {
+                    ExecutionError::DuplicateAttribute(format!(
+                        "{} on {} at {} and {}",
+                        attribute.name.display_with(exec.ctx),
+                        node.display_with(exec.graph),
+                        prev_debug_info.unwrap(),
+                        self.debug_info,
+                    ))
+                })?;
+        }
         Ok(())
+    }
+}
+
+impl DisplayWithContextAndGraph for AddGraphNodeAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(f, "attr ({})", self.node.display_with(ctx, graph))?;
+        for attr in &self.attributes {
+            write!(f, " {}", attr.display_with(ctx, graph))?;
+        }
+        write!(f, " at {}", self.debug_info)
+    }
+}
+
+/// Lazy statement to create a graph edge
+#[derive(Debug)]
+pub struct CreateEdge {
+    source: Value,
+    sink: Value,
+    debug_info: DebugInfo,
+}
+
+impl CreateEdge {
+    pub fn new(source: Value, sink: Value, debug_info: DebugInfo) -> CreateEdge {
+        CreateEdge {
+            source,
+            sink,
+            debug_info,
+        }
+    }
+
+    pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
+        let source = self.source.evaluate_as_graph_node(exec)?;
+        let sink = self.sink.evaluate_as_graph_node(exec)?;
+        let prev_debug_info = exec
+            .prev_element_debug_info
+            .insert(GraphElementKey::Edge(source, sink), self.debug_info);
+        if let Err(_) = exec.graph[source].add_edge(sink) {
+            Err(ExecutionError::DuplicateEdge(format!(
+                "({} -> {}) at {} and {}",
+                source.display_with(exec.graph),
+                sink.display_with(exec.graph),
+                prev_debug_info.unwrap(),
+                self.debug_info,
+            )))?;
+        }
+        Ok(())
+    }
+}
+
+impl DisplayWithContextAndGraph for CreateEdge {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(
+            f,
+            "edge {} -> {} at {}",
+            self.source.display_with(ctx, graph),
+            self.sink.display_with(ctx, graph),
+            self.debug_info,
+        )
+    }
+}
+
+/// Lazy statement to add graph edge attributes
+#[derive(Debug)]
+pub struct AddEdgeAttribute {
+    source: Value,
+    sink: Value,
+    attributes: Vec<Attribute>,
+    debug_info: DebugInfo,
+}
+
+impl AddEdgeAttribute {
+    pub fn new(
+        source: Value,
+        sink: Value,
+        attributes: Vec<Attribute>,
+        debug_info: DebugInfo,
+    ) -> AddEdgeAttribute {
+        AddEdgeAttribute {
+            source,
+            sink,
+            attributes,
+            debug_info,
+        }
+    }
+
+    pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
+        let source = self.source.evaluate_as_graph_node(exec)?;
+        let sink = self.sink.evaluate_as_graph_node(exec)?;
+        for attribute in &self.attributes {
+            let value = attribute.value.evaluate(exec)?;
+            let edge = match exec.graph[source].get_edge_mut(sink) {
+                Some(edge) => Ok(edge),
+                None => Err(ExecutionError::UndefinedEdge(format!(
+                    "({} -> {}) at {}",
+                    source.display_with(exec.graph),
+                    sink.display_with(exec.graph),
+                    self.debug_info,
+                ))),
+            }?;
+            let prev_debug_info = exec.prev_element_debug_info.insert(
+                GraphElementKey::EdgeAttribute(source, sink, attribute.name),
+                self.debug_info,
+            );
+            edge.attributes.add(attribute.name, value).map_err(|_| {
+                ExecutionError::DuplicateAttribute(format!(
+                    "{} on edge ({} -> {}) at {} and {}",
+                    attribute.name.display_with(exec.ctx),
+                    source.display_with(exec.graph),
+                    sink.display_with(exec.graph),
+                    prev_debug_info.unwrap(),
+                    self.debug_info,
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl DisplayWithContextAndGraph for AddEdgeAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(
+            f,
+            "attr ({} -> {})",
+            self.source.display_with(ctx, graph),
+            self.sink.display_with(ctx, graph),
+        )?;
+        for attr in &self.attributes {
+            write!(f, " {}", attr.display_with(ctx, graph),)?;
+        }
+        write!(f, " at {}", self.debug_info)
+    }
+}
+
+/// Lazy attribute
+#[derive(Debug)]
+pub struct Attribute {
+    name: Identifier,
+    value: Value,
+}
+
+impl Attribute {
+    pub fn new(name: Identifier, value: Value) -> Attribute {
+        Attribute { name, value }
+    }
+}
+
+impl DisplayWithContextAndGraph for Attribute {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(
+            f,
+            "{} = {}",
+            self.name.display_with(ctx),
+            self.value.display_with(ctx, graph),
+        )
     }
 }

--- a/src/lazy_execution/store.rs
+++ b/src/lazy_execution/store.rs
@@ -1,0 +1,297 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines store and thunks for lazy DSL evaluation
+
+use anyhow::Context as _;
+use log::trace;
+
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::convert::From;
+use std::fmt;
+use std::rc::Rc;
+
+use crate::execution::ExecutionError;
+use crate::graph;
+use crate::graph::DisplayWithGraph;
+use crate::graph::Graph;
+use crate::graph::SyntaxNodeRef;
+use crate::parser::Location;
+use crate::Context;
+use crate::DisplayWithContext;
+use crate::Identifier;
+
+use super::values::*;
+use super::DisplayWithContextAndGraph;
+use super::EvaluationContext;
+
+/// Variable that points to a thunk in the store
+#[derive(Clone, Debug)]
+pub struct Variable {
+    store_location: usize,
+}
+
+impl Variable {
+    fn new(store_location: usize) -> Variable {
+        Variable { store_location }
+    }
+
+    pub(super) fn evaluate(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<graph::Value, ExecutionError> {
+        exec.store.evaluate(self, exec)
+    }
+}
+
+impl DisplayWithContextAndGraph for Variable {
+    fn fmt(&self, f: &mut fmt::Formatter, _ctx: &Context, _graph: &Graph) -> fmt::Result {
+        write!(f, "(load {})", self.store_location)
+    }
+}
+
+/// Store holding thunks of lazy values
+#[derive(Default)]
+pub struct Store {
+    elements: Vec<Thunk>,
+}
+
+impl Store {
+    pub fn new() -> Store {
+        Store {
+            elements: Vec::new(),
+        }
+    }
+
+    pub fn add(
+        &mut self,
+        value: Value,
+        debug_info: DebugInfo,
+        ctx: &Context,
+        graph: &Graph,
+    ) -> Variable {
+        let store_location = self.elements.len();
+        let variable = Variable::new(store_location);
+        trace!(
+            "store {} = {}",
+            store_location,
+            value.display_with(ctx, graph)
+        );
+        self.elements.push(Thunk::new(value, debug_info));
+        variable
+    }
+
+    pub(super) fn evaluate(
+        &self,
+        variable: &Variable,
+        exec: &mut EvaluationContext,
+    ) -> Result<graph::Value, ExecutionError> {
+        let variable = &self.elements[variable.store_location];
+        let debug_info = variable.debug_info;
+        let value = variable.force(exec).with_context(|| {
+            format!(
+                "via {} at {}",
+                (*variable.state.borrow()).display_with(exec.ctx, exec.graph),
+                debug_info
+            )
+        })?;
+        Ok(value)
+    }
+}
+
+/// Data structure to hold scoped variables with lazy keys and values
+pub struct ScopedVariables {
+    variables: HashMap<Identifier, Cell<ScopedValues>>,
+}
+
+impl ScopedVariables {
+    pub fn new() -> ScopedVariables {
+        ScopedVariables {
+            variables: HashMap::new(),
+        }
+    }
+
+    pub fn add(
+        &mut self,
+        scope: Value,
+        name: Identifier,
+        value: Value,
+        debug_info: DebugInfo,
+        ctx: &Context,
+    ) -> Result<(), ExecutionError> {
+        let values = self
+            .variables
+            .entry(name)
+            .or_insert_with(|| Cell::new(ScopedValues::new()));
+        match values.replace(ScopedValues::Forcing) {
+            ScopedValues::Unforced(mut pairs) => {
+                pairs.push((scope, value, debug_info));
+                values.replace(ScopedValues::Unforced(pairs));
+                Ok(())
+            }
+            ScopedValues::Forcing => Err(ExecutionError::RecursivelyDefinedScopedVariable(
+                format!("{}", name.display_with(ctx)),
+            )),
+            ScopedValues::Forced(map) => {
+                values.replace(ScopedValues::Forced(map));
+                Err(ExecutionError::VariableScopesAlreadyForced(format!(
+                    "{}",
+                    name.display_with(ctx)
+                )))
+            }
+        }
+    }
+
+    pub(super) fn evaluate(
+        &self,
+        scope: SyntaxNodeRef,
+        name: Identifier,
+        exec: &mut EvaluationContext,
+    ) -> Result<Value, ExecutionError> {
+        let values = match self.variables.get(&name) {
+            Some(v) => v,
+            None => {
+                return Err(ExecutionError::UndefinedScopedVariable(format!(
+                    "{}.{}",
+                    scope.display_with(exec.graph),
+                    name.display_with(exec.ctx),
+                )));
+            }
+        };
+        match values.replace(ScopedValues::Forcing) {
+            ScopedValues::Unforced(pairs) => {
+                let mut map = HashMap::new();
+                let mut debug_infos = HashMap::new();
+                for (scope, value, debug_info) in pairs.into_iter() {
+                    let node = scope.evaluate_as_syntax_node(exec)?;
+                    let prev_debug_info = debug_infos.insert(node, debug_info.clone());
+                    match map.insert(node, value.clone()) {
+                        Some(_) => {
+                            return Err(ExecutionError::DuplicateVariable(format!(
+                                "{}.{} set at {} and {}",
+                                node.display_with(exec.graph),
+                                name.display_with(exec.ctx),
+                                prev_debug_info.unwrap(),
+                                debug_info,
+                            )));
+                        }
+                        _ => {}
+                    };
+                }
+                let result = map
+                    .get(&scope)
+                    .ok_or(ExecutionError::UndefinedScopedVariable(format!(
+                        "{}.{}",
+                        scope.display_with(exec.graph),
+                        name.display_with(exec.ctx),
+                    )))?
+                    .clone();
+                values.replace(ScopedValues::Forced(map));
+                Ok(result)
+            }
+            ScopedValues::Forcing => {
+                Err(ExecutionError::RecursivelyDefinedScopedVariable(format!(
+                    "_.{} requested on {}",
+                    name.display_with(exec.ctx),
+                    scope.display_with(exec.graph)
+                )))
+            }
+            ScopedValues::Forced(map) => {
+                let result = map
+                    .get(&scope)
+                    .ok_or(ExecutionError::UndefinedScopedVariable(format!(
+                        "{}.{}",
+                        scope.display_with(exec.graph),
+                        name.display_with(exec.ctx),
+                    )))?
+                    .clone();
+                values.replace(ScopedValues::Forced(map));
+                Ok(result)
+            }
+        }
+    }
+}
+
+enum ScopedValues {
+    Unforced(Vec<(Value, Value, DebugInfo)>),
+    Forcing,
+    Forced(HashMap<SyntaxNodeRef, Value>),
+}
+
+impl ScopedValues {
+    fn new() -> ScopedValues {
+        ScopedValues::Unforced(Vec::new())
+    }
+}
+
+/// Thunk holding a lazy value or a forced graph value
+struct Thunk {
+    state: Rc<RefCell<ThunkState>>,
+    debug_info: DebugInfo,
+}
+
+enum ThunkState {
+    Unforced(Value),
+    Forcing,
+    Forced(graph::Value),
+}
+
+impl DisplayWithContextAndGraph for ThunkState {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        match self {
+            Self::Unforced(value) => write!(f, "?{{{}}}", value.display_with(ctx, graph)),
+            Self::Forcing => write!(f, "~{{?}}"),
+            Self::Forced(value) => write!(f, "!{{{}}}", value.display_with(graph)),
+        }
+    }
+}
+
+impl Thunk {
+    fn new(value: Value, debug_info: DebugInfo) -> Thunk {
+        Thunk {
+            state: Rc::new(RefCell::new(ThunkState::Unforced(value))),
+            debug_info,
+        }
+    }
+
+    fn force(&self, exec: &mut EvaluationContext) -> Result<graph::Value, ExecutionError> {
+        let state = self.state.replace(ThunkState::Forcing);
+        trace!("force {}", state.display_with(exec.ctx, exec.graph));
+        let value = match state {
+            ThunkState::Unforced(value) => {
+                // it is important that we do not hold a borrow of self.forced_values when executing self.value.evaluate
+                let value = value.evaluate(exec)?;
+                Ok(value)
+            }
+            ThunkState::Forced(value) => Ok(value),
+            ThunkState::Forcing => Err(ExecutionError::RecursivelyDefinedVariable(format!(
+                "{}",
+                self.debug_info
+            ))),
+        }?;
+        *self.state.borrow_mut() = ThunkState::Forced(value.clone());
+        Ok(value)
+    }
+}
+
+/// Debug info for tracking origins of values
+#[derive(Debug, Clone, Copy)]
+pub struct DebugInfo(Location);
+
+impl From<Location> for DebugInfo {
+    fn from(value: Location) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for DebugInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/lazy_execution/values.rs
+++ b/src/lazy_execution/values.rs
@@ -1,0 +1,354 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines values for lazy DSL evaluation
+
+use log::trace;
+
+use std::convert::From;
+use std::fmt;
+
+use crate::execution::ExecutionError;
+use crate::graph;
+use crate::graph::DisplayWithGraph;
+use crate::graph::Graph;
+use crate::graph::GraphNodeRef;
+use crate::graph::SyntaxNodeRef;
+use crate::Context;
+use crate::DisplayWithContext;
+use crate::Identifier;
+
+use super::store::*;
+use super::DisplayWithContextAndGraph;
+use super::EvaluationContext;
+
+/// Lazy values
+#[derive(Clone, Debug)]
+pub enum Value {
+    Value(graph::Value),
+    List(List),
+    Set(Set),
+    Variable(Variable),
+    ScopedVariable(ScopedVariable),
+    Call(Call),
+}
+
+impl From<graph::Value> for Value {
+    fn from(value: graph::Value) -> Self {
+        Value::Value(value)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Value::Value(value.into())
+    }
+}
+
+impl From<u32> for Value {
+    fn from(value: u32) -> Self {
+        Value::Value(value.into())
+    }
+}
+
+impl From<&str> for Value {
+    fn from(value: &str) -> Self {
+        Value::Value(value.into())
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::Value(value.into())
+    }
+}
+
+impl From<GraphNodeRef> for Value {
+    fn from(value: GraphNodeRef) -> Self {
+        Value::Value(value.into())
+    }
+}
+
+impl From<SyntaxNodeRef> for Value {
+    fn from(value: SyntaxNodeRef) -> Self {
+        Value::Value(value.into())
+    }
+}
+
+impl From<Vec<graph::Value>> for Value {
+    fn from(value: Vec<graph::Value>) -> Self {
+        Value::Value(value.into())
+    }
+}
+
+impl From<List> for Value {
+    fn from(value: List) -> Self {
+        Value::List(value)
+    }
+}
+
+impl From<Vec<Value>> for Value {
+    fn from(value: Vec<Value>) -> Self {
+        Value::List(List::new(value))
+    }
+}
+
+impl From<Set> for Value {
+    fn from(value: Set) -> Self {
+        Value::Set(value)
+    }
+}
+
+impl From<Variable> for Value {
+    fn from(value: Variable) -> Self {
+        Value::Variable(value)
+    }
+}
+
+impl From<ScopedVariable> for Value {
+    fn from(value: ScopedVariable) -> Self {
+        Value::ScopedVariable(value)
+    }
+}
+
+impl From<Call> for Value {
+    fn from(value: Call) -> Self {
+        Value::Call(value)
+    }
+}
+
+impl Value {
+    pub(super) fn evaluate(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<graph::Value, ExecutionError> {
+        trace!("eval {} {{", self.display_with(exec.ctx, exec.graph));
+        let ret = match self {
+            Self::Value(value) => Ok(value.clone()),
+            Self::List(expr) => expr.evaluate(exec),
+            Self::Set(expr) => expr.evaluate(exec),
+            Self::Variable(expr) => expr.evaluate(exec),
+            Self::ScopedVariable(expr) => expr.evaluate(exec),
+            Self::Call(expr) => expr.evaluate(exec),
+        }?;
+        trace!("}} = {}", ret.display_with(exec.graph));
+        Ok(ret)
+    }
+
+    pub(super) fn evaluate_as_graph_node(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<GraphNodeRef, ExecutionError> {
+        let node = self.evaluate(exec)?;
+        match node {
+            graph::Value::GraphNode(node) => Ok(node),
+            _ => Err(ExecutionError::ExpectedGraphNode(format!(
+                " got {}",
+                node.display_with(exec.graph)
+            ))),
+        }
+    }
+
+    pub(super) fn evaluate_as_syntax_node(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<SyntaxNodeRef, ExecutionError> {
+        let node = self.evaluate(exec)?;
+        match node {
+            graph::Value::SyntaxNode(node) => Ok(node),
+            _ => Err(ExecutionError::ExpectedSyntaxNode(format!(
+                " got {}",
+                node.display_with(exec.graph)
+            ))),
+        }
+    }
+}
+
+impl DisplayWithContextAndGraph for Value {
+    fn fmt<'tree>(
+        &self,
+        f: &mut fmt::Formatter,
+        ctx: &Context,
+        graph: &Graph<'tree>,
+    ) -> fmt::Result {
+        match self {
+            Self::Value(value) => write!(f, "{}", value.display_with(graph)),
+            Self::List(expr) => expr.fmt(f, ctx, graph),
+            Self::Set(expr) => expr.fmt(f, ctx, graph),
+            Self::Variable(expr) => expr.fmt(f, ctx, graph),
+            Self::ScopedVariable(expr) => expr.fmt(f, ctx, graph),
+            Self::Call(expr) => expr.fmt(f, ctx, graph),
+        }
+    }
+}
+
+/// Lazy scoped variable
+#[derive(Clone, Debug)]
+pub struct ScopedVariable {
+    scope: Box<Value>,
+    name: Identifier,
+}
+
+impl ScopedVariable {
+    pub fn new(scope: Value, name: Identifier) -> ScopedVariable {
+        ScopedVariable {
+            scope: scope.into(),
+            name,
+        }
+    }
+
+    fn resolve<'a>(&self, exec: &'a mut EvaluationContext) -> Result<Value, ExecutionError> {
+        let scope = self.scope.as_ref().evaluate_as_syntax_node(exec)?;
+        let scoped_store = &exec.scoped_store;
+        scoped_store.evaluate(scope, self.name, exec)
+    }
+
+    pub(super) fn evaluate(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<graph::Value, ExecutionError> {
+        let value = self.resolve(exec)?;
+        value.evaluate(exec)
+    }
+}
+
+impl DisplayWithContextAndGraph for ScopedVariable {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(
+            f,
+            "(scoped {} '{})",
+            self.scope.display_with(ctx, graph),
+            self.name.display_with(ctx),
+        )
+    }
+}
+
+/// Lazy list literal
+#[derive(Clone, Debug)]
+pub struct List {
+    elements: Vec<Value>,
+}
+
+impl List {
+    pub fn new(elements: Vec<Value>) -> List {
+        List { elements }
+    }
+
+    pub(super) fn evaluate(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<graph::Value, ExecutionError> {
+        let elements = self
+            .elements
+            .iter()
+            .map(|e| e.evaluate(exec))
+            .collect::<Result<_, _>>()?;
+        Ok(graph::Value::List(elements))
+    }
+}
+
+impl DisplayWithContextAndGraph for List {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(f, "(list")?;
+        let mut first = true;
+        for elem in &self.elements {
+            if first {
+                first = false;
+                write!(f, "{}", elem.display_with(ctx, graph))?;
+            } else {
+                write!(f, " {}", elem.display_with(ctx, graph))?;
+            }
+        }
+        write!(f, ")")
+    }
+}
+
+/// Lazy set literal
+#[derive(Clone, Debug)]
+pub struct Set {
+    elements: Vec<Value>,
+}
+
+impl Set {
+    pub fn new(elements: Vec<Value>) -> Set {
+        Set { elements }
+    }
+
+    pub(super) fn evaluate(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<graph::Value, ExecutionError> {
+        let elements = self
+            .elements
+            .iter()
+            .map(|e| e.evaluate(exec))
+            .collect::<Result<_, _>>()?;
+        Ok(graph::Value::Set(elements))
+    }
+}
+
+impl DisplayWithContextAndGraph for Set {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(f, "(set")?;
+        let mut first = true;
+        for elem in &self.elements {
+            if first {
+                first = false;
+                write!(f, "{}", elem.display_with(ctx, graph))?;
+            } else {
+                write!(f, " {}", elem.display_with(ctx, graph))?;
+            }
+        }
+        write!(f, ")")
+    }
+}
+
+/// Lazy function call
+#[derive(Clone, Debug)]
+pub struct Call {
+    function: Identifier,
+    arguments: Vec<Value>,
+}
+
+impl Call {
+    pub fn new(function: Identifier, arguments: Vec<Value>) -> Call {
+        Call {
+            function,
+            arguments,
+        }
+    }
+
+    pub(super) fn evaluate(
+        &self,
+        exec: &mut EvaluationContext,
+    ) -> Result<graph::Value, ExecutionError> {
+        for argument in &self.arguments {
+            let argument = argument.evaluate(exec)?;
+            exec.function_parameters.push(argument);
+        }
+
+        exec.functions.call(
+            exec.ctx,
+            self.function,
+            exec.graph,
+            exec.source,
+            &mut exec
+                .function_parameters
+                .drain(exec.function_parameters.len() - self.arguments.len()..),
+        )
+    }
+}
+
+impl DisplayWithContextAndGraph for Call {
+    fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context, graph: &Graph) -> fmt::Result {
+        write!(f, "(call '{}", self.function.display_with(ctx))?;
+        for arg in &self.arguments {
+            write!(f, " {}", arg.display_with(ctx, graph))?;
+        }
+        write!(f, ")")
+    }
+}

--- a/src/lazy_execution/variables.rs
+++ b/src/lazy_execution/variables.rs
@@ -1,0 +1,166 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! Defines variable context for lazy DSL evaluation
+
+use log::debug;
+
+use crate::graph::Graph;
+use crate::Context;
+use crate::DisplayWithContext;
+use crate::Identifier;
+
+use super::store::DebugInfo;
+use super::store::Store;
+use super::values::Value;
+use super::DisplayWithContextAndGraph;
+
+/// An environment of named lazy variables
+pub trait Variables {
+    /// Adds a new variable to an environment, returning an error if the variable already
+    /// exists.
+    fn add(
+        &mut self,
+        name: Identifier,
+        value: Value,
+        mutable: bool,
+        debug_info: DebugInfo,
+        exec: &mut VariableContext,
+    ) -> Result<(), ()>;
+
+    /// Sets the variable, returning an error if it does not exists in this environment.
+    fn set(
+        &mut self,
+        name: Identifier,
+        value: Value,
+        debug_info: DebugInfo,
+        exec: &mut VariableContext,
+    ) -> Result<(), ()>;
+
+    /// Returns the value of a variable, if it exists in this environment.
+    fn get(&self, name: Identifier, exec: &VariableContext) -> Option<&Value>;
+}
+
+pub struct VariableContext<'a, 'tree> {
+    pub ctx: &'a Context,
+    pub graph: &'a Graph<'tree>,
+    pub store: &'a mut Store,
+}
+
+/// A map-like implementation of an environment of named lazy variables
+#[derive(Default)]
+pub struct VariableMap<'a> {
+    parent: Option<&'a mut dyn Variables>,
+    values: Vec<NamedVariable>,
+}
+
+struct NamedVariable {
+    name: Identifier,
+    value: Value,
+    mutable: bool,
+}
+
+impl<'a> VariableMap<'a> {
+    /// Creates a new, empty environment of variables.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new, empty environment of variables.
+    pub fn new_child(parent: &'a mut dyn Variables) -> Self {
+        Self {
+            parent: Some(parent),
+            values: Vec::default(),
+        }
+    }
+
+    /// Clears this list of variables.
+    pub fn clear(&mut self) {
+        self.values.clear();
+    }
+}
+
+impl Variables for VariableMap<'_> {
+    fn add(
+        &mut self,
+        name: Identifier,
+        value: Value,
+        mutable: bool,
+        debug_info: DebugInfo,
+        exec: &mut VariableContext,
+    ) -> Result<(), ()> {
+        if mutable {
+            debug!(
+                "var {} = {}",
+                name.display_with(exec.ctx),
+                value.display_with(exec.ctx, exec.graph)
+            );
+        } else {
+            debug!(
+                "let {} = {}",
+                name.display_with(exec.ctx),
+                value.display_with(exec.ctx, exec.graph)
+            );
+        }
+        match self.values.binary_search_by_key(&name, |v| v.name) {
+            Ok(_) => Err(()),
+            Err(index) => {
+                let value = exec.store.add(value, debug_info, exec.ctx, exec.graph);
+                let variable = NamedVariable {
+                    name,
+                    value: value.into(),
+                    mutable,
+                };
+                self.values.insert(index, variable);
+                Ok(())
+            }
+        }
+    }
+
+    fn set(
+        &mut self,
+        name: Identifier,
+        value: Value,
+        debug_info: DebugInfo,
+        exec: &mut VariableContext,
+    ) -> Result<(), ()> {
+        debug!(
+            "set {} = {}",
+            name.display_with(exec.ctx),
+            value.display_with(exec.ctx, exec.graph)
+        );
+        match self.values.binary_search_by_key(&name, |v| v.name) {
+            Ok(index) => {
+                let value = exec.store.add(value, debug_info, exec.ctx, exec.graph);
+                let variable = &mut self.values[index];
+                if variable.mutable {
+                    variable.value = value.into();
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+            Err(_) => self
+                .parent
+                .as_mut()
+                .map(|parent| parent.set(name, value, debug_info, exec))
+                .unwrap_or(Err(())),
+        }
+    }
+
+    fn get(&self, name: Identifier, exec: &VariableContext) -> Option<&Value> {
+        debug!("get {}", name.display_with(exec.ctx));
+        match self.values.binary_search_by_key(&name, |v| v.name) {
+            Ok(index) => Some(&self.values[index].value),
+            Err(_) => self
+                .parent
+                .as_ref()
+                .map(|parent| parent.get(name, exec))
+                .flatten(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod ast;
 mod execution;
 pub mod functions;
 pub mod graph;
+mod lazy_execution;
 mod parser;
 
 pub use execution::ExecutionError;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,6 +20,8 @@ use crate::ast;
 use crate::Context;
 use crate::Identifier;
 
+pub const FULL_MATCH: &str = "__tsg__full_match";
+
 impl ast::File {
     /// Parses a graph DSL file, adding its content to an existing `File` instance.
     pub fn parse(&mut self, ctx: &mut Context, content: &str) -> Result<(), ParseError> {
@@ -249,8 +251,8 @@ impl Parser<'_> {
         let query_start = self.offset;
         self.skip_query()?;
         let query_end = self.offset;
-        let query_source = &self.source[query_start..query_end];
-        Ok(Query::new(language, query_source)?)
+        let query_source = self.source[query_start..query_end].to_owned() + "@" + FULL_MATCH;
+        Ok(Query::new(language, &query_source)?)
     }
 
     fn skip_query(&mut self) -> Result<(), ParseError> {

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -13,7 +13,17 @@ use tree_sitter_graph::Context;
 use tree_sitter_graph::ExecutionError;
 use tree_sitter_graph::Variables;
 
+fn init_log() {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .format_level(false)
+        .format_target(false)
+        .format_timestamp(None)
+        .try_init(); // try, because earlier test may have already initialized it
+}
+
 fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionError> {
+    init_log();
     let mut parser = Parser::new();
     parser.set_language(tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -607,6 +607,130 @@ fn variables_are_inherited_in_if_body() {
 }
 
 #[test]
+fn can_execute_for_in_nonempty_list() {
+    check_execution(
+        r#"
+          pass
+          pass
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)* @xs) @root
+          {
+            var n = 0
+            for x in @xs {
+              set n = (plus n 1)
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 3
+        "#},
+    );
+}
+
+#[test]
+fn can_execute_for_in_empty_list() {
+    check_execution(
+        r#"
+          pass
+        "#,
+        indoc! {r#"
+          (module (import_statement)* @xs) @root
+          {
+            var n = 0
+            for x in @xs {
+              set n = (plus n 1)
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 0
+        "#},
+    );
+}
+
+#[test]
+fn variables_are_local_in_for_in_body() {
+    check_execution(
+        r#"
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)* @xs) @root
+          {
+            let n = 1
+            for x in @xs {
+              let n = 2
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 1
+        "#},
+    );
+}
+
+#[test]
+fn variables_do_not_escape_for_in_body() {
+    check_execution(
+        r#"
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)* @xs) @root
+          {
+            var n = 1
+            for x in @xs {
+              var n = 2
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 1
+        "#},
+    );
+}
+
+#[test]
+fn variables_are_inherited_in_for_in_body() {
+    check_execution(
+        r#"
+          pass
+          pass
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)+ @xs) @root
+          {
+            var n = 0
+            for x in @xs {
+              set n = (plus n 1)
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 3
+        "#},
+    );
+}
+
+#[test]
 fn can_build_node() {
     check_execution(
         "pass",

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -404,6 +404,209 @@ fn can_create_nonempty_list_capture() {
 }
 
 #[test]
+fn can_execute_if_some() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (pass_statement)? @x) @root
+          {
+            node node0
+            if some @x {
+                attr (node0) val = 0
+            } else {
+              attr (node0) val = 1
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 0
+        "#},
+    );
+}
+
+#[test]
+fn can_execute_if_none() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (import_statement)? @x) @root
+          {
+            node node0
+            if none @x {
+                attr (node0) val = 0
+            } else {
+              attr (node0) val = 1
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 0
+        "#},
+    );
+}
+
+#[test]
+fn can_execute_if_some_and_none() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (import_statement)? @x (pass_statement)? @y) @root
+          {
+            node node0
+            if none @x, some @y {
+              attr (node0) val = 1
+            } elif some @y {
+              attr (node0) val = 0
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 1
+        "#},
+    );
+}
+
+#[test]
+fn can_execute_elif() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (import_statement)? @x (pass_statement)? @y) @root
+          {
+            node node0
+            if some @x {
+              attr (node0) val = 0
+            } elif some @y {
+              attr (node0) val = 1
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 1
+        "#},
+    );
+}
+
+#[test]
+fn can_execute_else() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (import_statement)? @x) @root
+          {
+            node node0
+            if some @x {
+              attr (node0) val = 0
+            } else {
+              attr (node0) val = 1
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 1
+        "#},
+    );
+}
+
+#[test]
+fn skip_if_without_true_conditions() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (import_statement)? @x (import_statement)? @y) @root
+          {
+            node node0
+            if some @x {
+              attr (node0) val = 0
+            } elif some @y {
+              attr (node0) val = 1
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+        "#},
+    );
+}
+
+#[test]
+fn variables_are_local_in_if_body() {
+    check_execution(
+        r#"
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)? @x) @root
+          {
+            let n = 1
+            if some @x {
+              let n = 2
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 1
+        "#},
+    );
+}
+
+#[test]
+fn variables_do_not_escape_if_body() {
+    check_execution(
+        r#"
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)? @xs) @root
+          {
+            var n = 1
+            if some @x {
+              var n = 2
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 1
+        "#},
+    );
+}
+
+#[test]
+fn variables_are_inherited_in_if_body() {
+    check_execution(
+        r#"
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)? @x) @root
+          {
+            var n = 1
+            if some @x {
+              set n = (plus n 1)
+            }
+            node node0
+            attr (node0) val = n
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: 2
+        "#},
+    );
+}
+
+#[test]
 fn can_build_node() {
     check_execution(
         "pass",

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -12,8 +12,17 @@ use tree_sitter_graph::Context;
 use tree_sitter_graph::ExecutionError;
 use tree_sitter_graph::Variables;
 
-#[allow(unused)]
+fn init_log() {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .format_level(false)
+        .format_target(false)
+        .format_timestamp(None)
+        .try_init(); // try, because earlier test may have already initialized it
+}
+
 fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionError> {
+    init_log();
     let mut parser = Parser::new();
     parser.set_language(tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -1,0 +1,46 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use tree_sitter::Parser;
+use tree_sitter_graph::ast::File;
+use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::Context;
+use tree_sitter_graph::ExecutionError;
+use tree_sitter_graph::Variables;
+
+#[allow(unused)]
+fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionError> {
+    let mut parser = Parser::new();
+    parser.set_language(tree_sitter_python::language()).unwrap();
+    let tree = parser.parse(python_source, None).unwrap();
+    let mut ctx = Context::new();
+    let mut file = File::new(tree_sitter_python::language());
+    file.parse(&mut ctx, dsl_source).expect("Cannot parse file");
+    let mut functions = Functions::stdlib(&mut ctx);
+    let mut globals = Variables::new();
+    globals
+        .add(ctx.add_identifier("filename"), "test.py".into())
+        .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
+    let graph = file.execute_lazy(&mut ctx, &tree, python_source, &mut functions, &globals)?;
+    let result = graph.display_with(&ctx).to_string();
+    Ok(result)
+}
+
+#[allow(unused)]
+fn check_execution(python_source: &str, dsl_source: &str, expected_graph: &str) {
+    match execute(python_source, dsl_source) {
+        Ok(actual_graph) => assert_eq!(actual_graph, expected_graph),
+        Err(e) => panic!("Could not execute file: {}", e),
+    }
+}
+
+#[allow(unused)]
+fn fail_execution(python_source: &str, dsl_source: &str) {
+    if let Ok(_) = execute(python_source, dsl_source) {
+        panic!("Execution succeeded unexpectedly");
+    }
+}

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
@@ -39,7 +40,6 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     Ok(result)
 }
 
-#[allow(unused)]
 fn check_execution(python_source: &str, dsl_source: &str, expected_graph: &str) {
     match execute(python_source, dsl_source) {
         Ok(actual_graph) => assert_eq!(actual_graph, expected_graph),
@@ -52,4 +52,456 @@ fn fail_execution(python_source: &str, dsl_source: &str) {
     if let Ok(_) = execute(python_source, dsl_source) {
         panic!("Execution succeeded unexpectedly");
     }
+}
+
+#[test]
+fn can_build_simple_graph() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            attr (node0) name = "node0", source = @root
+            let node1 = (node)
+            attr (node1) name = "node1"
+            edge node0 -> node1
+            attr (node0 -> node1) precedence = 14
+            node node2
+            attr (node2) name = "node2", parent = node1
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            name: "node0"
+            source: [syntax node module (1, 1)]
+          edge 0 -> 2
+            precedence: 14
+          node 1
+            name: "node2"
+            parent: [graph node 2]
+          node 2
+            name: "node1"
+        "#},
+    );
+}
+
+#[test]
+fn scoped_variables_carry_across_stanzas() {
+    check_execution(
+        indoc! {r#"
+          import a
+          from b import c
+          print(a.d.f)
+        "#},
+        indoc! {r#"
+          (identifier) @id
+          {
+            let @id.node = (node)
+          }
+
+          (identifier) @id
+          {
+            attr (@id.node) name = (source-text @id)
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            name: "a"
+          node 1
+            name: "b"
+          node 2
+            name: "c"
+          node 3
+            name: "print"
+          node 4
+            name: "a"
+          node 5
+            name: "d"
+          node 6
+            name: "f"
+        "#},
+    );
+}
+
+#[test]
+fn can_match_stanza_multiple_times() {
+    check_execution(
+        indoc! {r#"
+          import a
+          from b import c
+          print(a.d.f)
+        "#},
+        indoc! {r#"
+          (identifier) @id
+          {
+            node new_node
+            attr (new_node) name = (source-text @id)
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            name: "a"
+          node 1
+            name: "b"
+          node 2
+            name: "c"
+          node 3
+            name: "print"
+          node 4
+            name: "a"
+          node 5
+            name: "d"
+          node 6
+            name: "f"
+        "#},
+    );
+}
+
+#[test]
+fn can_use_global_variable() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node n
+            attr (n) filename = filename
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            filename: "test.py"
+    "#},
+    );
+}
+
+#[test]
+fn can_use_variable_multiple_times() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            let x = (node)
+            let y = x
+            let z = x
+            node n
+            attr (n) v1 = y, v2 = x
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            v1: [graph node 1]
+            v2: [graph node 1]
+          node 1
+        "#},
+    );
+}
+
+#[test]
+fn can_nest_function_calls() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            attr (node0) val = (replace "accacc" (replace "abc" "b" "c") (replace "abc" "a" "b"))
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: "bbcbbc"
+        "#},
+    );
+}
+
+#[test]
+fn can_create_present_optional_capture() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module (_)? @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: [syntax node pass_statement (1, 1)]
+        "#},
+    );
+}
+
+#[test]
+fn can_create_missing_optional_capture() {
+    check_execution(
+        indoc! {r#"
+        "#},
+        indoc! {r#"
+          (module (_)? @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: #null
+        "#},
+    );
+}
+
+#[test]
+fn can_create_empty_list_capture() {
+    check_execution(
+        indoc! {r#"
+        "#},
+        indoc! {r#"
+          (module (_)* @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: []
+        "#},
+    );
+}
+
+#[test]
+fn can_create_nonempty_list_capture() {
+    check_execution(
+        indoc! {r#"
+          pass
+          pass
+        "#},
+        indoc! {r#"
+          (module (_)+ @stmts)
+          {
+            node n
+            attr (n) stmts = @stmts
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            stmts: [[syntax node pass_statement (1, 1)], [syntax node pass_statement (2, 1)]]
+        "#},
+    );
+}
+
+#[test]
+fn can_build_node() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+          }
+        "#},
+        indoc! {r#"
+          node 0
+        "#},
+    );
+}
+
+#[test]
+fn can_build_node_with_attrs() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            attr (node0) name = "node0", source = @root
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            name: "node0"
+            source: [syntax node module (1, 1)]
+        "#},
+    );
+}
+
+#[test]
+fn can_build_edge() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            node node1
+            edge node0 -> node1
+          }
+        "#},
+        indoc! {r#"
+          node 0
+          edge 0 -> 1
+          node 1
+        "#},
+    );
+}
+
+#[test]
+fn can_build_edges() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            node node0
+            node node1
+            edge node0 -> node1
+            node node2
+            edge node1 -> node2
+            edge node2 -> node0
+          }
+        "#},
+        indoc! {r#"
+          node 0
+          edge 0 -> 1
+          node 1
+          edge 1 -> 2
+          node 2
+          edge 2 -> 0
+        "#},
+    );
+}
+
+#[test]
+fn can_set_mutable_local_variables() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            var node = #null
+
+            set node = (node)
+
+            let new_node = (node)
+            edge new_node -> node
+            set node = new_node
+          }
+        "#},
+        indoc! {r#"
+          node 0
+          edge 0 -> 1
+          node 1
+        "#},
+    );
+}
+
+#[test]
+fn scoped_variables_can_appear_out_of_order() {
+    check_execution(
+        indoc! {r#"
+          import a
+          from b import c
+          print(a.d.f)
+        "#},
+        indoc! {r#"
+          (identifier) @id
+          {
+            attr (@id.node) name = (source-text @id)
+          }
+
+          (identifier) @id
+          {
+            let @id.node = (node)
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            name: "a"
+          node 1
+            name: "b"
+          node 2
+            name: "c"
+          node 3
+            name: "print"
+          node 4
+            name: "a"
+          node 5
+            name: "d"
+          node 6
+            name: "f"
+        "#},
+    );
+}
+
+#[test]
+fn variables_can_be_scoped_in_arbitrary_expressions() {
+    check_execution(
+        indoc! {r#"
+          import a
+          from b import c
+          print(a.d.f)
+        "#},
+        indoc! {r#"
+          (call function:(_)@fun arguments: (argument_list (_)@arg)) {
+          ; let @arg.no_object.lala = 3 ; error
+            let @arg.object.lala = 3
+            let @arg.object.object.lala = 12
+          ; let @arg.object.object = 42 ; error
+          }
+          (attribute object:(_)@obj)@attr {
+            let @attr.object = @obj
+            let @attr.no_object = 7
+          }
+        "#},
+        indoc! {r#""#},
+    );
+}
+
+#[test]
+fn variable_let_executed_once() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            let x = (node)
+            attr ((node)) ref = x
+            attr ((node)) ref = x
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            ref: [graph node 1]
+          node 1
+          node 2
+            ref: [graph node 1]
+        "#},
+    );
+}
+
+#[test]
+fn variable_set_executed_once() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          (module) @root
+          {
+            var x = #null
+            set x = (node)
+            attr ((node)) ref = x
+            attr ((node)) ref = x
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            ref: [graph node 1]
+          node 1
+          node 2
+            ref: [graph node 1]
+        "#},
+    );
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -7,4 +7,5 @@
 
 mod execution;
 mod graph;
+mod lazy_execution;
 mod parser;


### PR DESCRIPTION
Adds lazy evaluation as an alternative execution strategy.

**Why**

Strict evaluation required careful ordering of the stanzas to make sure scoped variables were defined before they were used. This can get in the way of writing readable code.

**How**

The lazy evaluation strategy executes all stanzas on a given tree, but does not compute the values immediately. Instead, it computes thunks, that are forced only after _all_ stanzas have been executed when the graph is built in the second phase. The key part are the handling of scoped variables: initially both scope and value are thunks. Whenever a scoped variable is forced, all scopes for that scoped variable name are forced, but not yet their values, which are only forced when the scoped variable for its particular scope is forced.

**Limitations**

The lazy values are relatively simple and do not support control. This means control statements cannot depend on thunks, but only on values that are directly tied to the tree. While supporting lazy control is possible (see this [proof of concept](https://github.com/tree-sitter/tree-sitter-graph/tree/poc/lazy-evaluation-of-loops-and-conditionals)), it is not clear that the added complexity and possible runtime cost is justified.

**Use**

The API has new methods `execute_lazy{,_into}` that have the same signature as the (still existing) `execute{,_into}` methods, but use the new lazy evaluation strategy.

The CLI has a new `--lazy/-z` option to use the lazy strategy. The default is still the current, strict evaluation.