### PR TITLE
Merge stanza queries for lazy evaluation

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -661,7 +661,7 @@ impl From<Capture> for Expression {
 
 impl DisplayWithContext for Capture {
     fn fmt(&self, f: &mut fmt::Formatter, ctx: &Context) -> fmt::Result {
-        write!(f, "{}", self.name.display_with(ctx))
+        write!(f, "@{}", self.name.display_with(ctx))
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -645,8 +645,6 @@ impl DisplayWithContext for Call {
 /// A capture expression that references a syntax node
 #[derive(Debug, Eq, PartialEq)]
 pub struct Capture {
-    /// The index of this capture in the block's tree-sitter query
-    pub index: usize,
     /// The suffix of the capture
     pub quantifier: CaptureQuantifier,
     /// The name of the capture

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -22,6 +22,8 @@ use crate::Location;
 #[derive(Debug)]
 pub struct File {
     pub language: Language,
+    /// The combined query of all stanzas in the file
+    pub query: Option<Query>,
     /// The list of stanzas in the file
     pub stanzas: Vec<Stanza>,
 }
@@ -30,6 +32,7 @@ impl File {
     pub fn new(language: Language) -> File {
         File {
             language,
+            query: None,
             stanzas: Vec::new(),
         }
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -8,8 +8,11 @@
 mod variables;
 
 use anyhow::Context as ErrorContext;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use thiserror::Error;
 use tree_sitter::CaptureQuantifier;
+use tree_sitter::Query;
 use tree_sitter::QueryCursor;
 use tree_sitter::QueryMatch;
 use tree_sitter::Tree;
@@ -178,7 +181,7 @@ impl ExecutionError {
     }
 }
 
-struct ExecutionContext<'a, 'g, 's, 'tree> {
+struct ExecutionContext<'a, 'g, 's, 'q, 'tree> {
     ctx: &'a Context,
     source: &'tree str,
     graph: &'a mut Graph<'tree>,
@@ -188,6 +191,7 @@ struct ExecutionContext<'a, 'g, 's, 'tree> {
     scoped: &'a mut ScopedVariables<'s>,
     current_regex_captures: &'a Vec<String>,
     function_parameters: &'a mut Vec<Value>,
+    capture_indices: &'a mut CaptureIndices<'q>,
     mat: &'a QueryMatch<'a, 'tree>,
 }
 
@@ -206,6 +210,7 @@ impl Stanza {
         function_parameters: &mut Vec<Value>,
         cursor: &mut QueryCursor,
     ) -> Result<(), ExecutionError> {
+        let mut capture_indices = CaptureIndices::new(&self.query);
         let matches = cursor.matches(&self.query, tree.root_node(), source.as_bytes());
         for mat in matches {
             locals.clear();
@@ -219,6 +224,7 @@ impl Stanza {
                 scoped,
                 current_regex_captures,
                 function_parameters,
+                capture_indices: &mut capture_indices,
                 mat: &mat,
             };
             for statement in &self.statements {
@@ -395,6 +401,7 @@ impl Scan {
                 scoped: exec.scoped,
                 current_regex_captures: &current_regex_captures,
                 function_parameters: exec.function_parameters,
+                capture_indices: exec.capture_indices,
                 mat: exec.mat,
             };
 
@@ -462,6 +469,7 @@ impl If {
                     scoped: exec.scoped,
                     current_regex_captures: exec.current_regex_captures,
                     function_parameters: exec.function_parameters,
+                    capture_indices: exec.capture_indices,
                     mat: exec.mat,
                 };
                 for stmt in &arm.statements {
@@ -509,6 +517,7 @@ impl ForIn {
                 scoped: exec.scoped,
                 current_regex_captures: exec.current_regex_captures,
                 function_parameters: exec.function_parameters,
+                capture_indices: exec.capture_indices,
                 mat: exec.mat,
             };
             self.variable.add(&mut loop_exec, value, false)?;
@@ -589,8 +598,10 @@ impl SetComprehension {
 
 impl Capture {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
+        let name = exec.ctx.resolve(self.name);
+        let index = exec.capture_indices.index_for_name(name);
         Ok(query_capture_value(
-            self.index,
+            index,
             self.quantifier,
             exec.mat,
             exec.graph,
@@ -779,8 +790,38 @@ impl UnscopedVariable {
     }
 }
 
+/// Get and cache the index for a named capture
+pub(crate) struct CaptureIndices<'a> {
+    query: &'a Query,
+    indices: HashMap<String, usize>,
+}
+
+impl<'a> CaptureIndices<'a> {
+    pub(crate) fn new(query: &'a Query) -> Self {
+        CaptureIndices {
+            query,
+            indices: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn index_for_name(&mut self, name: &str) -> usize {
+        match self.indices.entry(name.into()) {
+            Entry::Occupied(o) => *o.get(),
+            Entry::Vacant(v) => {
+                let index = self
+                    .query
+                    .capture_names()
+                    .iter()
+                    .position(|n| n == name)
+                    .unwrap();
+                *v.insert(index)
+            }
+        }
+    }
+}
+
 /// Get the value for the given capture, considering the suffix
-pub fn query_capture_value<'tree>(
+pub(crate) fn query_capture_value<'tree>(
     index: usize,
     quantifier: CaptureQuantifier,
     mat: &QueryMatch<'_, 'tree>,

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -17,13 +17,13 @@ use std::collections::HashMap;
 use std::fmt;
 
 use tree_sitter::CaptureQuantifier::One;
-use tree_sitter::Query;
 use tree_sitter::QueryCursor;
 use tree_sitter::QueryMatch;
 use tree_sitter::Tree;
 
 use crate::ast;
 use crate::execution::query_capture_value;
+use crate::execution::CaptureIndices;
 use crate::execution::ExecutionError;
 use crate::execution::Globals;
 use crate::functions::Functions;
@@ -109,17 +109,19 @@ impl ast::File {
                 })
                 .with_context(|| format!("Executing {}", graph_stmt.display_with(ctx, &graph)))?;
         }
+
         Ok(())
     }
 }
 
 /// Context for execution, which executes stanzas to build the lazy graph
-struct ExecutionContext<'a, 'g, 'tree> {
+struct ExecutionContext<'a, 'g, 'q, 'tree> {
     ctx: &'a Context,
     graph: &'a mut Graph<'tree>,
     globals: &'a Globals<'g>,
     locals: &'a mut dyn Variables,
     current_regex_captures: &'a Vec<String>,
+    capture_indices: &'a mut CaptureIndices<'q>,
     mat: &'a QueryMatch<'a, 'tree>,
     store: &'a mut LazyStore,
     scoped_store: &'a mut LazyScopedVariables,
@@ -159,7 +161,8 @@ impl ast::Stanza {
         scoped_store: &mut LazyScopedVariables,
         lazy_graph: &mut Vec<LazyStatement>,
     ) -> Result<(), ExecutionError> {
-        let full_match_index = full_match_capture_index(&self.query);
+        let mut capture_indices = CaptureIndices::new(&self.query);
+        let full_match_index = capture_indices.index_for_name(FULL_MATCH);
         let current_regex_captures = vec![];
         let matches = cursor.matches(&self.query, tree.root_node(), source.as_bytes());
         for mat in matches {
@@ -170,6 +173,7 @@ impl ast::Stanza {
                 globals,
                 locals,
                 current_regex_captures: &current_regex_captures,
+                capture_indices: &mut capture_indices,
                 mat: &mat,
                 store,
                 scoped_store,
@@ -322,6 +326,7 @@ impl ast::Scan {
                 globals: exec.globals,
                 locals: &mut arm_locals,
                 current_regex_captures: &current_regex_captures,
+                capture_indices: exec.capture_indices,
                 mat: exec.mat,
                 store: exec.store,
                 scoped_store: exec.scoped_store,
@@ -390,6 +395,7 @@ impl ast::If {
                     globals: exec.globals,
                     locals: &mut arm_locals,
                     current_regex_captures: exec.current_regex_captures,
+                    capture_indices: exec.capture_indices,
                     mat: exec.mat,
                     store: exec.store,
                     scoped_store: exec.scoped_store,
@@ -436,6 +442,7 @@ impl ast::ForIn {
                 globals: exec.globals,
                 locals: &mut loop_locals,
                 current_regex_captures: exec.current_regex_captures,
+                capture_indices: exec.capture_indices,
                 mat: exec.mat,
                 store: exec.store,
                 scoped_store: exec.scoped_store,
@@ -510,8 +517,10 @@ impl ast::SetComprehension {
 
 impl ast::Capture {
     fn evaluate_strict(&self, exec: &mut ExecutionContext) -> Result<graph::Value, ExecutionError> {
+        let name = exec.ctx.resolve(self.name);
+        let index = exec.capture_indices.index_for_name(name);
         Ok(query_capture_value(
-            self.index,
+            index,
             self.quantifier,
             exec.mat,
             exec.graph,
@@ -519,7 +528,9 @@ impl ast::Capture {
     }
 
     fn evaluate_lazy(&self, exec: &mut ExecutionContext) -> Result<LazyValue, ExecutionError> {
-        Ok(query_capture_value(self.index, self.quantifier, exec.mat, exec.graph).into())
+        let name = exec.ctx.resolve(self.name);
+        let index = exec.capture_indices.index_for_name(name);
+        Ok(query_capture_value(index, self.quantifier, exec.mat, exec.graph).into())
     }
 }
 
@@ -738,14 +749,6 @@ impl ast::Attribute {
         let attribute = LazyAttribute::new(self.name, value);
         Ok(attribute)
     }
-}
-
-fn full_match_capture_index(query: &Query) -> usize {
-    query
-        .capture_names()
-        .iter()
-        .position(|c| c == FULL_MATCH)
-        .unwrap()
 }
 
 /// Trait to Display with a given Context and Graph

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -755,22 +755,14 @@ impl Parser<'_> {
         }
         self.consume_while(is_ident);
         let end = self.offset;
-        let capture_name = &self.source[start + 1..end];
-        let index = current_query
-            .capture_names()
-            .iter()
-            .position(|c| c == capture_name);
+        let name = &self.source[start + 1..end];
+        let index = current_query.capture_names().iter().position(|c| c == name);
         let index = match index {
             Some(index) => index,
-            None => {
-                return Err(ParseError::UndefinedCapture(
-                    capture_name.into(),
-                    capture_location,
-                ))
-            }
+            None => return Err(ParseError::UndefinedCapture(name.into(), capture_location)),
         };
         let quantifier = current_query.capture_quantifiers(0)[index];
-        let name = self.ctx.add_identifier(&self.source[start..end]);
+        let name = self.ctx.add_identifier(name);
         Ok(ast::Capture {
             index,
             quantifier,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -763,12 +763,7 @@ impl Parser<'_> {
         };
         let quantifier = current_query.capture_quantifiers(0)[index];
         let name = self.ctx.add_identifier(name);
-        Ok(ast::Capture {
-            index,
-            quantifier,
-            name,
-        }
-        .into())
+        Ok(ast::Capture { quantifier, name }.into())
     }
 
     fn parse_integer_constant(&mut self) -> Result<ast::Expression, ParseError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,6 +94,7 @@ struct Parser<'a> {
     chars: Peekable<Chars<'a>>,
     offset: usize,
     location: Location,
+    query_source: String,
     // Keywords
     attr_keyword: Identifier,
     edge_keyword: Identifier,
@@ -121,6 +122,8 @@ fn is_ident(c: char) -> bool {
 impl<'a> Parser<'a> {
     fn new(ctx: &'a mut Context, source: &'a str) -> Parser<'a> {
         let chars = source.chars().peekable();
+        let query_source = String::with_capacity(source.len());
+        // Keywords
         let attr_keyword = ctx.add_identifier("attr");
         let edge_keyword = ctx.add_identifier("edge");
         let false_keyword = ctx.add_identifier("false");
@@ -140,6 +143,8 @@ impl<'a> Parser<'a> {
             chars,
             offset: 0,
             location: Location::default(),
+            query_source,
+            // Keywords
             attr_keyword,
             edge_keyword,
             false_keyword,
@@ -232,6 +237,7 @@ impl Parser<'_> {
             file.stanzas.push(stanza);
             self.consume_whitespace();
         }
+        file.query = Some(Query::new(file.language, &self.query_source)?);
         Ok(())
     }
 
@@ -252,6 +258,11 @@ impl Parser<'_> {
         self.skip_query()?;
         let query_end = self.offset;
         let query_source = self.source[query_start..query_end].to_owned() + "@" + FULL_MATCH;
+        // If tree-sitter allowed us to incrementally add patterns to a query, we wouldn't need
+        // the global query_source and could compute the cpature indices in the AST instead of
+        // having to resolve the capture names at execution time.
+        self.query_source += &query_source;
+        self.query_source += "\n";
         Ok(Query::new(language, &query_source)?)
     }
 

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -59,7 +59,6 @@ fn can_parse_blocks() {
                 node: ScopedVariable {
                     scope: Box::new(
                         Capture {
-                            index: 1,
                             quantifier: One,
                             name: cap2,
                         }
@@ -76,7 +75,6 @@ fn can_parse_blocks() {
                 source: ScopedVariable {
                     scope: Box::new(
                         Capture {
-                            index: 1,
                             quantifier: One,
                             name: cap2,
                         }
@@ -98,7 +96,6 @@ fn can_parse_blocks() {
                 source: ScopedVariable {
                     scope: Box::new(
                         Capture {
-                            index: 1,
                             quantifier: One,
                             name: cap2,
                         }
@@ -124,7 +121,6 @@ fn can_parse_blocks() {
                 node: ScopedVariable {
                     scope: Box::new(
                         Capture {
-                            index: 1,
                             quantifier: One,
                             name: cap2,
                         }
@@ -151,7 +147,6 @@ fn can_parse_blocks() {
                 variable: ScopedVariable {
                     scope: Box::new(
                         Capture {
-                            index: 1,
                             quantifier: One,
                             name: cap2,
                         }
@@ -173,7 +168,6 @@ fn can_parse_blocks() {
                 variable: ScopedVariable {
                     scope: Box::new(
                         Capture {
-                            index: 1,
                             quantifier: One,
                             name: cap2,
                         }
@@ -531,7 +525,6 @@ fn can_parse_star_capture() {
         statements,
         vec![vec![Print {
             values: vec![Capture {
-                index: 0,
                 quantifier: ZeroOrMore,
                 name: stmts,
             }
@@ -568,7 +561,6 @@ fn can_parse_star_multiple_capture() {
         vec![vec![
             Print {
                 values: vec![Capture {
-                    index: 0,
                     quantifier: ZeroOrMore,
                     name: stmt,
                 }
@@ -578,7 +570,6 @@ fn can_parse_star_multiple_capture() {
             .into(),
             Print {
                 values: vec![Capture {
-                    index: 1,
                     quantifier: ZeroOrMore,
                     name: stmts,
                 }
@@ -613,7 +604,6 @@ fn can_parse_plus_capture() {
         statements,
         vec![vec![Print {
             values: vec![Capture {
-                index: 0,
                 quantifier: OneOrMore,
                 name: stmts,
             }
@@ -647,7 +637,6 @@ fn can_parse_optional_capture() {
         statements,
         vec![vec![Print {
             values: vec![Capture {
-                index: 0,
                 quantifier: ZeroOrOne,
                 name: stmt,
             }
@@ -681,7 +670,6 @@ fn can_parse_parent_optional_capture() {
         statements,
         vec![vec![Print {
             values: vec![Capture {
-                index: 0,
                 quantifier: ZeroOrOne,
                 name: stmt,
             }
@@ -715,7 +703,6 @@ fn can_parse_alternative_capture() {
         statements,
         vec![vec![Print {
             values: vec![Capture {
-                index: 0,
                 quantifier: ZeroOrOne,
                 name: stmt,
             }
@@ -749,7 +736,6 @@ fn can_parse_nested_plus_and_optional_capture() {
         statements,
         vec![vec![Print {
             values: vec![Capture {
-                index: 0,
                 quantifier: ZeroOrMore,
                 name: stmt,
             }
@@ -786,7 +772,6 @@ fn can_parse_if() {
         vec![vec![If {
             arms: vec![IfArm {
                 conditions: vec![Condition::Some(vec![Capture {
-                    index: 0,
                     quantifier: ZeroOrOne,
                     name: x,
                 }])],
@@ -835,7 +820,6 @@ fn can_parse_if_elif() {
             arms: vec![
                 IfArm {
                     conditions: vec![Condition::None(vec![Capture {
-                        index: 0,
                         quantifier: ZeroOrOne,
                         name: x,
                     }])],
@@ -851,7 +835,6 @@ fn can_parse_if_elif() {
                 },
                 IfArm {
                     conditions: vec![Condition::Some(vec![Capture {
-                        index: 0,
                         quantifier: ZeroOrOne,
                         name: x,
                     }])],
@@ -901,7 +884,6 @@ fn can_parse_if_else() {
             arms: vec![
                 IfArm {
                     conditions: vec![Condition::None(vec![Capture {
-                        index: 0,
                         quantifier: ZeroOrOne,
                         name: x,
                     }])],
@@ -981,7 +963,6 @@ fn can_parse_for_in() {
                 location: Location { row: 3, column: 14 }
             },
             capture: Capture {
-                index: 0,
                 quantifier: ZeroOrMore,
                 name: xs,
             }

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -35,7 +35,7 @@ fn can_parse_blocks() {
     let pop = ctx.add_identifier("pop");
     let prop1 = ctx.add_identifier("prop1");
     let push = ctx.add_identifier("push");
-    let cap2 = ctx.add_identifier("@cap2");
+    let cap2 = ctx.add_identifier("cap2");
     let var1 = ctx.add_identifier("var1");
 
     let statements = file
@@ -61,7 +61,7 @@ fn can_parse_blocks() {
                         Capture {
                             index: 1,
                             quantifier: One,
-                            name: cap2
+                            name: cap2,
                         }
                         .into()
                     ),
@@ -78,7 +78,7 @@ fn can_parse_blocks() {
                         Capture {
                             index: 1,
                             quantifier: One,
-                            name: cap2
+                            name: cap2,
                         }
                         .into()
                     ),
@@ -100,7 +100,7 @@ fn can_parse_blocks() {
                         Capture {
                             index: 1,
                             quantifier: One,
-                            name: cap2
+                            name: cap2,
                         }
                         .into()
                     ),
@@ -126,7 +126,7 @@ fn can_parse_blocks() {
                         Capture {
                             index: 1,
                             quantifier: One,
-                            name: cap2
+                            name: cap2,
                         }
                         .into()
                     ),
@@ -153,7 +153,7 @@ fn can_parse_blocks() {
                         Capture {
                             index: 1,
                             quantifier: One,
-                            name: cap2
+                            name: cap2,
                         }
                         .into()
                     ),
@@ -175,7 +175,7 @@ fn can_parse_blocks() {
                         Capture {
                             index: 1,
                             quantifier: One,
-                            name: cap2
+                            name: cap2,
                         }
                         .into()
                     ),
@@ -520,7 +520,7 @@ fn can_parse_star_capture() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let stmts = ctx.add_identifier("@stmts");
+    let stmts = ctx.add_identifier("stmts");
 
     let statements = file
         .stanzas
@@ -555,8 +555,8 @@ fn can_parse_star_multiple_capture() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("@stmt");
-    let stmts = ctx.add_identifier("@stmts");
+    let stmt = ctx.add_identifier("stmt");
+    let stmts = ctx.add_identifier("stmts");
 
     let statements = file
         .stanzas
@@ -602,7 +602,7 @@ fn can_parse_plus_capture() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let stmts = ctx.add_identifier("@stmts");
+    let stmts = ctx.add_identifier("stmts");
 
     let statements = file
         .stanzas
@@ -636,7 +636,7 @@ fn can_parse_optional_capture() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("@stmt");
+    let stmt = ctx.add_identifier("stmt");
 
     let statements = file
         .stanzas
@@ -670,7 +670,7 @@ fn can_parse_parent_optional_capture() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("@stmt");
+    let stmt = ctx.add_identifier("stmt");
 
     let statements = file
         .stanzas
@@ -704,7 +704,7 @@ fn can_parse_alternative_capture() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("@stmt");
+    let stmt = ctx.add_identifier("stmt");
 
     let statements = file
         .stanzas
@@ -738,7 +738,7 @@ fn can_parse_nested_plus_and_optional_capture() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let stmt = ctx.add_identifier("@stmt");
+    let stmt = ctx.add_identifier("stmt");
 
     let statements = file
         .stanzas
@@ -774,7 +774,7 @@ fn can_parse_if() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let x = ctx.add_identifier("@x");
+    let x = ctx.add_identifier("x");
 
     let statements = file
         .stanzas
@@ -822,7 +822,7 @@ fn can_parse_if_elif() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let x = ctx.add_identifier("@x");
+    let x = ctx.add_identifier("x");
 
     let statements = file
         .stanzas
@@ -888,7 +888,7 @@ fn can_parse_if_else() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let x = ctx.add_identifier("@x");
+    let x = ctx.add_identifier("x");
 
     let statements = file
         .stanzas
@@ -965,7 +965,7 @@ fn can_parse_for_in() {
     let mut file = File::new(tree_sitter_python::language());
     file.parse(&mut ctx, source).expect("Cannot parse file");
 
-    let xs = ctx.add_identifier("@xs");
+    let xs = ctx.add_identifier("xs");
     let x = ctx.add_identifier("x");
 
     let statements = file


### PR DESCRIPTION
Implements an optimization that merges all stanza queries into a single multi-pattern query for lazy evaluation. This single query is matches against the tree, instead of going through all stanzas one by one and matching each against the tree.

**Limitations**

This optimization cannot be applied to strict evaluation, since the evaluation order there must be deterministic.