### PR TITLE
Add explicit global variable declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### DSL
+
+#### Added
+
+- Global variable declarations.
+
+#### Deprecated
+
+- Use of undeclared global variables.
+
+### Library
+
+#### Changed
+
+- Calls to `execute` will fail with a runtime error if declared global variables are missing in the global environment.
+
 ## 0.3.0 - 2022-02-08
 
 ### DSL

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,6 +20,8 @@ use crate::Location;
 #[derive(Debug)]
 pub struct File {
     pub language: Language,
+    /// The expected global variables used in this file
+    pub globals: Vec<Global>,
     /// The combined query of all stanzas in the file
     pub query: Option<Query>,
     /// The list of stanzas in the file
@@ -30,10 +32,21 @@ impl File {
     pub fn new(language: Language) -> File {
         File {
             language,
+            globals: Vec::new(),
             query: None,
             stanzas: Vec::new(),
         }
     }
+}
+
+/// A global variable
+#[derive(Debug, Eq, PartialEq)]
+pub struct Global {
+    /// The name of the global variable
+    pub name: Identifier,
+    /// The quantifier of the global variable
+    pub quantifier: CaptureQuantifier,
+    pub location: Location,
 }
 
 /// One stanza within a file

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -66,6 +66,7 @@ impl ast::File {
         if tree.root_node().has_error() {
             return Err(ExecutionError::ParseTreeHasErrors);
         }
+        self.check_globals(globals)?;
         let mut locals = VariableMap::new();
         let mut cursor = QueryCursor::new();
         let mut store = LazyStore::new();

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -192,20 +192,24 @@
 //!     to stanza.  Scoped variables are referenced by using a syntax node expression (typically a
 //!     query capture) and a variable name, separated by a period: `@node.variable`.
 //!
+//! Global variables are declared using a `global` declaration.  The external process that executes the
+//! graph DSL file must provide values for all declared global variables.  (It is not possible to define
+//! a global variable and give it a value from within the graph DSL.) The name of the global variable can
+//! be suffixed by a quantifier: '*' and '+' for lists, and '?' for optional values, which allows them to
+//! be used in iteration and conditional statements, respectively.
+//!
 //! Local and scoped variables are created using `var` or `let` statements.  A `let` statement
 //! creates an **_immutable variable_**, whose value cannot be changed.  A `var` statement creates
 //! a **_mutable variable_**.  You use a `set` statement to change the value of a mutable variable.
+//! Local variables are not allowed to have the same name as a declared global variable.
 //!
 //! Local variables are block scoped.  For example, a local variable defined in a `scan` arm is not
 //! visible in other scan arms, or after the `scan` statement.  If you need to persist a value for use
 //! after a block, introduce a mutable variable before the block and assign to it inside the block.
 //!
-//! (All global variables are immutable, and cannot be created by any graph DSL statement; they are
-//! only provided by the external process that executes the graph DSL file.  If you need to create
-//! your own "global" variable from within the graph DSL, create a scoped variable on the root
-//! syntax node.)
-//!
 //! ``` tsg
+//! global global_variable
+//!
 //! (identifier) @id
 //! {
 //!   let local_variable = "a string"
@@ -216,8 +220,12 @@
 //!   ; doesn't exist:
 //!   ; set missing_variable = 42
 //!
+//!   ; The following is an error, since you cannot hide a global variable with
+//!   ; a local one:
+//!   ; let global_variable = "a new value"
+//!
 //!   var mutable_variable = "first value"
-//!   set mutable_variable = "second value"
+//!   set mutable_variable = global_variable ; we can refer to the global variable
 //!
 //!   var @id.kind = "id"
 //! }
@@ -381,6 +389,8 @@
 //! module defined in the file:
 //!
 //! ``` tsg
+//! global filepath
+//!
 //! (module) @mod
 //! {
 //!   var new_node = #null

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -252,6 +252,8 @@ fn can_use_global_variable() {
     check_execution(
         "pass",
         indoc! {r#"
+          global filename
+
           (module) @root
           {
             node n
@@ -262,6 +264,31 @@ fn can_use_global_variable() {
           node 0
             filename: "test.py"
     "#},
+    );
+}
+
+#[test]
+fn cannot_omit_global_variable() {
+    fail_execution(
+        "pass",
+        indoc! {r#"
+          global root
+
+          (identifier) {
+            node n
+            edge n -> root
+          }
+        "#},
+    );
+}
+
+#[test]
+fn cannot_pass_string_to_global_list_variable() {
+    fail_execution(
+        "pass",
+        indoc! {r#"
+          global filename*
+        "#},
     );
 }
 

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -253,6 +253,8 @@ fn can_use_global_variable() {
     check_execution(
         "pass",
         indoc! {r#"
+          global filename
+
           (module) @root
           {
             node n
@@ -263,6 +265,21 @@ fn can_use_global_variable() {
           node 0
             filename: "test.py"
     "#},
+    );
+}
+
+#[test]
+fn cannot_omit_global_variable() {
+    fail_execution(
+        "pass",
+        indoc! {r#"
+          global root
+
+          (identifier) {
+            node n
+            edge n -> root
+          }
+        "#},
     );
 }
 


### PR DESCRIPTION
Adds explicit global variable declarations to the DSL. For example:

    global filename

    (module) {
      scan filename {
        ; ...
      }
    }

These declarations are **required** for any global variable that is used in stanzas.

This has the following advantages:
- DSL files are now completely self-contained (no free variables in stanzas), and explicit about their requirements for execution.
- Variable references can now be checked at parse time, and errors are caught without having to hit a stanza that uses the missing variable.
- When executing a DSL file, the global environment is checked if all required variables are there. Again, giving early feedback of problems, instead of having to execute until the missing variable is used.

Using undeclared globals is deprecated with this change. A warning is displayed when an undefined variable is encountered (which is then assumed to be global) that it should be declared. Eventually, declaring all globals will be required.

See this example for how they can be used: https://github.com/hendrikvanantwerpen/tree-sitter-typescript/blob/add-stack-graph/queries/stack-graphs.tsg#L13-L17