### PR TITLE
Add support for attribute shorthands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Global variable declarations.
+- Attribute shorthands.
 
 #### Deprecated
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -752,13 +752,11 @@ impl AttributeShorthands {
         self.0.insert(shorthand.name.clone(), shorthand);
     }
 
-    pub fn iter(&self) -> std::collections::hash_map::Values<Identifier, AttributeShorthand> {
+    pub fn iter(&self) -> impl Iterator<Item = &AttributeShorthand> {
         self.0.values()
     }
 
-    pub fn into_iter(
-        self,
-    ) -> std::collections::hash_map::IntoValues<Identifier, AttributeShorthand> {
+    pub fn into_iter(self) -> impl Iterator<Item = AttributeShorthand> {
         self.0.into_values()
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,6 +8,7 @@
 //! Defines the AST structure of a graph DSL file
 
 use regex::Regex;
+use std::collections::HashMap;
 use std::fmt;
 use tree_sitter::CaptureQuantifier;
 use tree_sitter::Language;
@@ -26,6 +27,8 @@ pub struct File {
     pub query: Option<Query>,
     /// The list of stanzas in the file
     pub stanzas: Vec<Stanza>,
+    /// Attribute shorthands defined in the file
+    pub shorthands: AttributeShorthands,
 }
 
 impl File {
@@ -35,6 +38,7 @@ impl File {
             globals: Vec::new(),
             query: None,
             stanzas: Vec::new(),
+            shorthands: AttributeShorthands::new(),
         }
     }
 }
@@ -728,5 +732,52 @@ impl From<UnscopedVariable> for Expression {
 impl From<ScopedVariable> for Expression {
     fn from(variable: ScopedVariable) -> Expression {
         Expression::Variable(variable.into())
+    }
+}
+
+/// Attribute shorthands
+#[derive(Debug, Eq, PartialEq)]
+pub struct AttributeShorthands(HashMap<Identifier, AttributeShorthand>);
+
+impl AttributeShorthands {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn get(&self, name: &Identifier) -> Option<&AttributeShorthand> {
+        self.0.get(name)
+    }
+
+    pub fn add(&mut self, shorthand: AttributeShorthand) {
+        self.0.insert(shorthand.name.clone(), shorthand);
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Values<Identifier, AttributeShorthand> {
+        self.0.values()
+    }
+
+    pub fn into_iter(
+        self,
+    ) -> std::collections::hash_map::IntoValues<Identifier, AttributeShorthand> {
+        self.0.into_values()
+    }
+}
+
+/// An attribute shorthand
+#[derive(Debug, Eq, PartialEq)]
+pub struct AttributeShorthand {
+    pub name: Identifier,
+    pub variable: UnscopedVariable,
+    pub attributes: Vec<Attribute>,
+    pub location: Location,
+}
+
+impl std::fmt::Display for AttributeShorthand {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "attribute {} = {} =>", self.name, self.variable,)?;
+        for attr in &self.attributes {
+            write!(f, " {}", attr)?;
+        }
+        write!(f, " at {}", self.location)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,6 +217,10 @@ impl<'a> Parser<'a> {
                 self.consume_whitespace();
                 let global = self.parse_global()?;
                 file.globals.push(global);
+            } else if let Ok(_) = self.consume_token("attribute") {
+                self.consume_whitespace();
+                let shorthand = self.parse_shorthand()?;
+                file.shorthands.add(shorthand);
             } else {
                 let stanza = self.parse_stanza(file.language)?;
                 file.stanzas.push(stanza);
@@ -234,6 +238,25 @@ impl<'a> Parser<'a> {
         Ok(ast::Global {
             name,
             quantifier,
+            location,
+        })
+    }
+
+    fn parse_shorthand(&mut self) -> Result<ast::AttributeShorthand, ParseError> {
+        let location = self.location;
+        let name = self.parse_identifier("shorthand name")?;
+        self.consume_whitespace();
+        self.consume_token("=")?;
+        self.consume_whitespace();
+        let variable = self.parse_unscoped_variable()?;
+        self.consume_whitespace();
+        self.consume_token("=>")?;
+        self.consume_whitespace();
+        let attributes = self.parse_attributes()?;
+        Ok(ast::AttributeShorthand {
+            name,
+            variable,
+            attributes,
             location,
         })
     }

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -364,6 +364,23 @@
 //! execution has completed, the variables disappear.  Attributes, on the other hand, are part of
 //! the output produced by the graph DSL file, and live on after execution has finished.)
 //!
+//! ## Attribute shorthands
+//!
+//! Commonly used combinations of attributes can be captured in **_shorthands_**.  Each shorthand defines
+//! the attribute name, a variable which captures the attribute value, and a list of attributes to which
+//! it expands.
+//!
+//! Attribute shorthands are defined at the same level as stanzas.  For example, the following shorthand
+//! takes a syntax node as argument, and expands to attributes for its source text and child index:
+//!
+//! ``` tsg
+//! attribute node_props = node => node_text = (source-text node), node_index = (named-child-index node)
+//!
+//! (argument (_)@expr) {
+//!   attr (@expr) node_props = @expr
+//! }
+//! ```
+//!
 //! # Regular expressions
 //!
 //! You can use a `scan` statement to match the content of a string value against a set of regular

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -847,3 +847,25 @@ fn can_execute_scan_of_local_variable() {
         "#},
     );
 }
+
+#[test]
+fn can_execute_shorthand() {
+    check_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            attribute def = x => source_node = x, symbol = (source-text x)
+            (function_definition name: (identifier) @name) {
+              node n
+              attr (n) def = @name
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            source_node: [syntax node identifier (1, 5)]
+            symbol: "get_f"
+        "#},
+    );
+}

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -1366,3 +1366,25 @@ fn variable_set_executed_once() {
         "#},
     );
 }
+
+#[test]
+fn can_execute_shorthand() {
+    check_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            attribute def = x => source_node = x, symbol = (source-text x)
+            (function_definition name: (identifier) @name) {
+              node n
+              attr (n) def = @name
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            source_node: [syntax node identifier (1, 5)]
+            symbol: "get_f"
+        "#},
+    );
+}

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -1366,3 +1366,50 @@ fn cannot_parse_set_global() {
         panic!("Parse succeeded unexpectedly");
     }
 }
+
+#[test]
+fn can_parse_shorthand() {
+    let source = r#"
+        attribute def = x => source_node = x, symbol = (source-text x)
+        (function_definition name: (identifier) @name) {
+          node n
+          attr (n) sh = @name
+        }
+    "#;
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
+
+    let shorthands = file.shorthands.into_iter().collect::<Vec<_>>();
+    assert_eq!(
+        shorthands,
+        vec![AttributeShorthand {
+            name: "def".into(),
+            variable: UnscopedVariable {
+                name: "x".into(),
+                location: Location { row: 1, column: 24 }
+            },
+            attributes: vec![
+                Attribute {
+                    name: "source_node".into(),
+                    value: UnscopedVariable {
+                        name: "x".into(),
+                        location: Location { row: 1, column: 43 }
+                    }
+                    .into()
+                },
+                Attribute {
+                    name: "symbol".into(),
+                    value: Call {
+                        function: "source-text".into(),
+                        parameters: vec![UnscopedVariable {
+                            name: "x".into(),
+                            location: Location { row: 1, column: 68 }
+                        }
+                        .into()]
+                    }
+                    .into(),
+                }
+            ],
+            location: Location { row: 1, column: 18 }
+        }]
+    );
+}


### PR DESCRIPTION
This adds support for shorthand attributes, attributes that are expanded to a set of other attributes. For example:

``` tsg
attribute node_props = node => node_text = (source-text node), node_index = (named-child-index node)

(argument (_)@expr) {
  attr (@expr) node_props = @expr
}
```

See this example for how they can be used to introduce compact notation for common attribute combinations: https://github.com/hendrikvanantwerpen/tree-sitter-typescript/blob/add-stack-graph/queries/stack-graphs.tsg#L19-L35