### PR TITLE
Implicit debug attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Module `parse_error` for finding and displaying `tree-sitter` parse errors.
+- Option in `ExecutionConfig` to automatically add debug graph node attributes that describe the source location and variable name of the originating `node` statement in the DSL source.
 
 #### Changed
 
 - Calls to `execute` will fail with a runtime error if declared global variables are missing in the global environment.
 - Calls to `execute` will not fail early on parse trees with errors. Errors may occur during query execution if matched parts of the tree are missing.
+- The seperate arguments to `execute` are replaced by a single `ExecutionConfig` argument, which makes it easier to add optional arguments without breaking all use sites.
+
+#### Removed
+
+- The `execute_lazy` method has been removed. Lazy evalaution is enabled by setting the `lazy` flag in the `ExecutionConfig`.
 
 ### CLI
 

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -17,6 +17,7 @@ use tree_sitter_config::Config;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::parse_error::ParseError;
+use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Variables;
 use tree_sitter_loader::Loader;
 
@@ -99,10 +100,11 @@ fn main() -> Result<()> {
 
     let mut functions = Functions::stdlib();
     let globals = Variables::new();
+    let options = ExecutionOptions::new();
     let graph = if lazy {
-        file.execute_lazy(&tree, &source, &mut functions, &globals)
+        file.execute_lazy(&tree, &source, &mut functions, &globals, &options)
     } else {
-        file.execute(&tree, &source, &mut functions, &globals)
+        file.execute(&tree, &source, &mut functions, &globals, &options)
     }
     .with_context(|| format!("Error executing TSG file {}", tsg_path.display()))?;
 

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -100,13 +100,10 @@ fn main() -> Result<()> {
 
     let mut functions = Functions::stdlib();
     let globals = Variables::new();
-    let options = ExecutionOptions::new();
-    let graph = if lazy {
-        file.execute_lazy(&tree, &source, &mut functions, &globals, &options)
-    } else {
-        file.execute(&tree, &source, &mut functions, &globals, &options)
-    }
-    .with_context(|| format!("Error executing TSG file {}", tsg_path.display()))?;
+    let mut config = ExecutionConfig::new(&mut functions, &globals).lazy(lazy);
+    let graph = file
+        .execute(&tree, &source, &mut config)
+        .with_context(|| format!("Cannot execute TSG file {}", tsg_path.display()))?;
 
     let json = matches.is_present("json");
     if json {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -289,7 +289,7 @@ impl Attributes {
         self.values.get(name.borrow())
     }
 
-    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, Identifier, Value> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Identifier, &Value)> {
         self.values.iter()
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -288,6 +288,10 @@ impl Attributes {
     {
         self.values.get(name.borrow())
     }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, Identifier, Value> {
+        self.values.iter()
+    }
 }
 
 impl std::fmt::Display for Attributes {

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -21,12 +21,11 @@ use tree_sitter::Tree;
 
 use crate::ast;
 use crate::execution::query_capture_value;
+use crate::execution::ExecutionConfig;
 use crate::execution::ExecutionError;
-use crate::execution::ExecutionOptions;
 use crate::functions::Functions;
 use crate::graph;
 use crate::graph::Graph;
-use crate::variables::Globals;
 use crate::variables::VariableMap;
 use crate::variables::Variables;
 use crate::Identifier;
@@ -36,37 +35,19 @@ use store::*;
 use values::*;
 
 impl ast::File {
-    /// Executes this graph DSL file against a source file.  You must provide the parsed syntax
-    /// tree (`tree`) as well as the source text that it was parsed from (`source`).  You also
-    /// provide the set of functions and global variables that are available during execution.
-    pub fn execute_lazy<'tree>(
-        &self,
-        tree: &'tree Tree,
-        source: &'tree str,
-        functions: &mut Functions,
-        globals: &Globals,
-        options: &ExecutionOptions,
-    ) -> Result<Graph<'tree>, ExecutionError> {
-        let mut graph = Graph::new();
-        self.execute_lazy_into(&mut graph, tree, source, functions, globals, options)?;
-        Ok(graph)
-    }
-
     /// Executes this graph DSL file against a source file, saving the results into an existing
     /// `Graph` instance.  You must provide the parsed syntax tree (`tree`) as well as the source
     /// text that it was parsed from (`source`).  You also provide the set of functions and global
     /// variables that are available during execution. This variant is useful when you need to
     /// “pre-seed” the graph with some predefined nodes and/or edges before executing the DSL file.
-    pub fn execute_lazy_into<'tree>(
+    pub(crate) fn execute_lazy_into<'tree>(
         &self,
         graph: &mut Graph<'tree>,
         tree: &'tree Tree,
         source: &'tree str,
-        functions: &mut Functions,
-        globals: &Globals,
-        options: &ExecutionOptions,
+        config: &mut ExecutionConfig,
     ) -> Result<(), ExecutionError> {
-        self.check_globals(globals)?;
+        self.check_globals(config.globals)?;
         let mut locals = VariableMap::new();
         let mut cursor = QueryCursor::new();
         let mut store = LazyStore::new();
@@ -83,9 +64,7 @@ impl ast::File {
                 source,
                 &mat,
                 graph,
-                functions,
-                globals,
-                options,
+                config,
                 &mut locals,
                 &mut store,
                 &mut scoped_store,
@@ -101,7 +80,7 @@ impl ast::File {
                 .evaluate(&mut EvaluationContext {
                     source,
                     graph,
-                    functions,
+                    functions: config.functions,
                     store: &mut store,
                     scoped_store: &mut scoped_store,
                     function_parameters: &mut function_parameters,
@@ -115,12 +94,10 @@ impl ast::File {
 }
 
 /// Context for execution, which executes stanzas to build the lazy graph
-struct ExecutionContext<'a, 'g, 'tree> {
+struct ExecutionContext<'a, 'c, 'g, 'tree> {
     source: &'tree str,
     graph: &'a mut Graph<'tree>,
-    functions: &'a mut Functions,
-    globals: &'a Globals<'g>,
-    options: &'a ExecutionOptions,
+    config: &'a mut ExecutionConfig<'c, 'g>,
     locals: &'a mut dyn Variables<LazyValue>,
     current_regex_captures: &'a Vec<String>,
     mat: &'a QueryMatch<'a, 'tree>,
@@ -151,14 +128,12 @@ pub(super) enum GraphElementKey {
 }
 
 impl ast::Stanza {
-    fn execute_lazy<'l, 'g, 'q, 'tree>(
+    fn execute_lazy<'a, 'l, 'g, 'q, 'tree>(
         &self,
         source: &'tree str,
         mat: &QueryMatch<'_, 'tree>,
         graph: &mut Graph<'tree>,
-        functions: &mut Functions,
-        globals: &Globals<'g>,
-        options: &ExecutionOptions,
+        config: &mut ExecutionConfig,
         locals: &mut VariableMap<'l, LazyValue>,
         store: &mut LazyStore,
         scoped_store: &mut LazyScopedVariables,
@@ -172,9 +147,7 @@ impl ast::Stanza {
         let mut exec = ExecutionContext {
             source,
             graph,
-            functions,
-            globals,
-            options,
+            config,
             locals,
             current_regex_captures: &current_regex_captures,
             mat,
@@ -240,10 +213,8 @@ impl ast::Assign {
 impl ast::CreateGraphNode {
     fn execute_lazy(&self, exec: &mut ExecutionContext) -> Result<(), ExecutionError> {
         let graph_node = exec.graph.add_graph_node();
-        if exec.options.implicit_debug_attrs {
-            self.node
-                .add_debug_attrs(&mut exec.graph[graph_node].attributes);
-        }
+        self.node
+            .add_debug_attrs(&mut exec.graph[graph_node].attributes, exec.config)?;
         self.node.add_lazy(exec, graph_node.into(), false)
     }
 }
@@ -330,9 +301,7 @@ impl ast::Scan {
             let mut arm_exec = ExecutionContext {
                 source: exec.source,
                 graph: exec.graph,
-                functions: exec.functions,
-                globals: exec.globals,
-                options: exec.options,
+                config: exec.config,
                 locals: &mut arm_locals,
                 current_regex_captures: &current_regex_captures,
                 mat: exec.mat,
@@ -392,9 +361,7 @@ impl ast::If {
                 let mut arm_exec = ExecutionContext {
                     source: exec.source,
                     graph: exec.graph,
-                    functions: exec.functions,
-                    globals: exec.globals,
-                    options: exec.options,
+                    config: exec.config,
                     locals: &mut arm_locals,
                     current_regex_captures: exec.current_regex_captures,
                     mat: exec.mat,
@@ -436,9 +403,7 @@ impl ast::ForIn {
             let mut loop_exec = ExecutionContext {
                 source: exec.source,
                 graph: exec.graph,
-                functions: exec.functions,
-                globals: exec.globals,
-                options: exec.options,
+                config: exec.config,
                 locals: &mut loop_locals,
                 current_regex_captures: exec.current_regex_captures,
                 mat: exec.mat,
@@ -482,7 +447,7 @@ impl ast::Expression {
         self.evaluate_lazy(exec)?.evaluate(&mut EvaluationContext {
             source: exec.source,
             graph: exec.graph,
-            functions: exec.functions,
+            functions: exec.config.functions,
             store: exec.store,
             scoped_store: exec.scoped_store,
             function_parameters: exec.function_parameters,
@@ -629,7 +594,7 @@ impl ast::ScopedVariable {
 
 impl ast::UnscopedVariable {
     fn evaluate_lazy(&self, exec: &mut ExecutionContext) -> Result<LazyValue, ExecutionError> {
-        if let Some(value) = exec.globals.get(&self.name) {
+        if let Some(value) = exec.config.globals.get(&self.name) {
             Some(value.clone().into())
         } else {
             exec.locals.get(&self.name).map(|value| value.clone())
@@ -645,7 +610,7 @@ impl ast::UnscopedVariable {
         value: LazyValue,
         mutable: bool,
     ) -> Result<(), ExecutionError> {
-        if exec.globals.get(&self.name).is_some() {
+        if exec.config.globals.get(&self.name).is_some() {
             return Err(ExecutionError::DuplicateVariable(format!(
                 " global {}",
                 self
@@ -662,7 +627,7 @@ impl ast::UnscopedVariable {
         exec: &mut ExecutionContext,
         value: LazyValue,
     ) -> Result<(), ExecutionError> {
-        if exec.globals.get(&self.name).is_some() {
+        if exec.config.globals.get(&self.name).is_some() {
             return Err(ExecutionError::CannotAssignImmutableVariable(format!(
                 " global {}",
                 self
@@ -714,9 +679,7 @@ impl ast::AttributeShorthand {
         let mut shorthand_exec = ExecutionContext {
             source: exec.source,
             graph: exec.graph,
-            functions: exec.functions,
-            globals: exec.globals,
-            options: exec.options,
+            config: exec.config,
             locals: &mut shorthand_locals,
             current_regex_captures: exec.current_regex_captures,
             mat: exec.mat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod parser;
 mod variables;
 
 pub use execution::ExecutionError;
+pub use execution::ExecutionOptions;
 pub use parser::Location;
 pub use parser::ParseError;
 pub use variables::Globals as Variables;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ pub mod parse_error;
 mod parser;
 mod variables;
 
+pub use execution::ExecutionConfig;
 pub use execution::ExecutionError;
-pub use execution::ExecutionOptions;
 pub use parser::Location;
 pub use parser::ParseError;
 pub use variables::Globals as Variables;

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -9,8 +9,8 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
-use tree_sitter_graph::ExecutionOptions;
 use tree_sitter_graph::Identifier;
 use tree_sitter_graph::Variables;
 
@@ -35,8 +35,8 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     globals
         .add(Identifier::from("filename"), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
-    let options = ExecutionOptions::new();
-    let graph = file.execute(&tree, python_source, &mut functions, &globals, &options)?;
+    let mut config = ExecutionConfig::new(&mut functions, &globals);
+    let graph = file.execute(&tree, python_source, &mut config)?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -10,6 +10,7 @@ use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::ExecutionError;
+use tree_sitter_graph::ExecutionOptions;
 use tree_sitter_graph::Identifier;
 use tree_sitter_graph::Variables;
 
@@ -34,7 +35,8 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     globals
         .add(Identifier::from("filename"), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
-    let graph = file.execute(&tree, python_source, &mut functions, &mut globals)?;
+    let options = ExecutionOptions::new();
+    let graph = file.execute(&tree, python_source, &mut functions, &globals, &options)?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -9,8 +9,8 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
-use tree_sitter_graph::ExecutionOptions;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -34,8 +34,8 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     globals
         .add("filename".into(), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
-    let options = ExecutionOptions::new();
-    let graph = file.execute_lazy(&tree, python_source, &mut functions, &globals, &options)?;
+    let mut config = ExecutionConfig::new(&mut functions, &globals).lazy(true);
+    let graph = file.execute(&tree, python_source, &mut config)?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -10,6 +10,7 @@ use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::ExecutionError;
+use tree_sitter_graph::ExecutionOptions;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -33,7 +34,8 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     globals
         .add("filename".into(), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
-    let graph = file.execute_lazy(&tree, python_source, &mut functions, &globals)?;
+    let options = ExecutionOptions::new();
+    let graph = file.execute_lazy(&tree, python_source, &mut functions, &globals, &options)?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }


### PR DESCRIPTION
This adds an option to have tree-sitter-graph implicitly add attributes to node that record the variable name and location in the TSG source which caused the creation of this node. This is useful for debugging.

The names for the attributes are provided by the user, so we don't clash with user attributes, or the user is able to use naming schemes that help further processing (something we do in tree-sitter-stack-graph).

Additionally, this changes the invocation of DSL execution to make it hopefully more resilient for future changes if such flags or options are introduced. Instead of passing separate parameters to `execute`, everything is grouped into an `ExecutionConfig` struct. Some values are required, and changing these will obviously break client code, but flags such as whether to use lazy execution are set by subsequent calls instead of required fields/parameters. As a result, there is not only a single public `execute` method, and lazy execution is called if the flag is set, instead of via a separate method.