### PR TITLE
Comprehensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Global variable declarations.
 - Attribute shorthands.
+- List and set comprehensions.
 
 #### Deprecated
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -530,6 +530,9 @@ pub enum Expression {
     // Literals
     ListLiteral(ListLiteral),
     SetLiteral(SetLiteral),
+    // Comprehensions
+    ListComprehension(ListComprehension),
+    SetComprehension(SetComprehension),
     // Syntax nodes
     Capture(Capture),
     // Variables
@@ -550,6 +553,8 @@ impl std::fmt::Display for Expression {
             Expression::StringConstant(expr) => expr.fmt(f),
             Expression::ListLiteral(expr) => expr.fmt(f),
             Expression::SetLiteral(expr) => expr.fmt(f),
+            Expression::ListComprehension(expr) => expr.fmt(f),
+            Expression::SetComprehension(expr) => expr.fmt(f),
             Expression::Capture(expr) => expr.fmt(f),
             Expression::Variable(expr) => expr.fmt(f),
             Expression::Call(expr) => expr.fmt(f),
@@ -653,6 +658,31 @@ impl std::fmt::Display for ListLiteral {
     }
 }
 
+/// An list comprehension
+#[derive(Debug, Eq, PartialEq)]
+pub struct ListComprehension {
+    pub element: Box<Expression>,
+    pub variable: UnscopedVariable,
+    pub value: Box<Expression>,
+    pub location: Location,
+}
+
+impl From<ListComprehension> for Expression {
+    fn from(expr: ListComprehension) -> Expression {
+        Expression::ListComprehension(expr)
+    }
+}
+
+impl std::fmt::Display for ListComprehension {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "[ {} for {} in {} ]",
+            self.element, self.variable, self.value
+        )
+    }
+}
+
 /// A reference to one of the regex captures in a `scan` statement
 #[derive(Debug, Eq, PartialEq)]
 pub struct RegexCapture {
@@ -696,6 +726,31 @@ impl std::fmt::Display for SetLiteral {
             }
         }
         write!(f, "}}")
+    }
+}
+
+/// An set comprehension
+#[derive(Debug, Eq, PartialEq)]
+pub struct SetComprehension {
+    pub element: Box<Expression>,
+    pub variable: UnscopedVariable,
+    pub value: Box<Expression>,
+    pub location: Location,
+}
+
+impl From<SetComprehension> for Expression {
+    fn from(expr: SetComprehension) -> Expression {
+        Expression::SetComprehension(expr)
+    }
+}
+
+impl std::fmt::Display for SetComprehension {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{{ {} for {} in {} }}",
+            self.element, self.variable, self.value
+        )
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -527,9 +527,9 @@ pub enum Expression {
     // Constants
     IntegerConstant(IntegerConstant),
     StringConstant(StringConstant),
-    // Comprehensions
-    List(ListComprehension),
-    Set(SetComprehension),
+    // Literals
+    ListLiteral(ListLiteral),
+    SetLiteral(SetLiteral),
     // Syntax nodes
     Capture(Capture),
     // Variables
@@ -548,8 +548,8 @@ impl std::fmt::Display for Expression {
             Expression::TrueLiteral => write!(f, "true"),
             Expression::IntegerConstant(expr) => expr.fmt(f),
             Expression::StringConstant(expr) => expr.fmt(f),
-            Expression::List(expr) => expr.fmt(f),
-            Expression::Set(expr) => expr.fmt(f),
+            Expression::ListLiteral(expr) => expr.fmt(f),
+            Expression::SetLiteral(expr) => expr.fmt(f),
             Expression::Capture(expr) => expr.fmt(f),
             Expression::Variable(expr) => expr.fmt(f),
             Expression::Call(expr) => expr.fmt(f),
@@ -627,17 +627,17 @@ impl std::fmt::Display for IntegerConstant {
 
 /// An ordered list of values
 #[derive(Debug, Eq, PartialEq)]
-pub struct ListComprehension {
+pub struct ListLiteral {
     pub elements: Vec<Expression>,
 }
 
-impl From<ListComprehension> for Expression {
-    fn from(expr: ListComprehension) -> Expression {
-        Expression::List(expr)
+impl From<ListLiteral> for Expression {
+    fn from(expr: ListLiteral) -> Expression {
+        Expression::ListLiteral(expr)
     }
 }
 
-impl std::fmt::Display for ListComprehension {
+impl std::fmt::Display for ListLiteral {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "[")?;
         let mut first = true;
@@ -673,17 +673,17 @@ impl std::fmt::Display for RegexCapture {
 
 /// An unordered set of values
 #[derive(Debug, Eq, PartialEq)]
-pub struct SetComprehension {
+pub struct SetLiteral {
     pub elements: Vec<Expression>,
 }
 
-impl From<SetComprehension> for Expression {
-    fn from(expr: SetComprehension) -> Expression {
-        Expression::Set(expr)
+impl From<SetLiteral> for Expression {
+    fn from(expr: SetLiteral) -> Expression {
+        Expression::SetLiteral(expr)
     }
 }
 
-impl std::fmt::Display for SetComprehension {
+impl std::fmt::Display for SetLiteral {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{{")?;
         let mut first = true;

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -346,8 +346,8 @@ impl ast::Expression {
             }),
             Self::IntegerConstant(expr) => expr.check(ctx),
             Self::StringConstant(expr) => expr.check(ctx),
-            Self::List(expr) => expr.check(ctx),
-            Self::Set(expr) => expr.check(ctx),
+            Self::ListLiteral(expr) => expr.check(ctx),
+            Self::SetLiteral(expr) => expr.check(ctx),
             Self::Capture(expr) => expr.check(ctx),
             Self::Variable(expr) => expr.check_get(ctx),
             Self::Call(expr) => expr.check(ctx),
@@ -374,7 +374,7 @@ impl ast::StringConstant {
     }
 }
 
-impl ast::ListComprehension {
+impl ast::ListLiteral {
     fn check(&mut self, ctx: &mut CheckContext) -> Result<ExpressionResult, CheckError> {
         let mut is_local = true;
         for element in &mut self.elements {
@@ -388,7 +388,7 @@ impl ast::ListComprehension {
     }
 }
 
-impl ast::SetComprehension {
+impl ast::SetLiteral {
     fn check(&mut self, ctx: &mut CheckContext) -> Result<ExpressionResult, CheckError> {
         let mut is_local = true;
         for element in &mut self.elements {

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -31,12 +31,12 @@ use crate::ast::File;
 use crate::ast::ForIn;
 use crate::ast::If;
 use crate::ast::IntegerConstant;
-use crate::ast::ListComprehension;
+use crate::ast::ListLiteral;
 use crate::ast::Print;
 use crate::ast::RegexCapture;
 use crate::ast::Scan;
 use crate::ast::ScopedVariable;
-use crate::ast::SetComprehension;
+use crate::ast::SetLiteral;
 use crate::ast::Stanza;
 use crate::ast::Statement;
 use crate::ast::StringConstant;
@@ -596,8 +596,8 @@ impl Expression {
             Expression::TrueLiteral => Ok(Value::Boolean(true)),
             Expression::IntegerConstant(expr) => expr.evaluate(exec),
             Expression::StringConstant(expr) => expr.evaluate(exec),
-            Expression::List(expr) => expr.evaluate(exec),
-            Expression::Set(expr) => expr.evaluate(exec),
+            Expression::ListLiteral(expr) => expr.evaluate(exec),
+            Expression::SetLiteral(expr) => expr.evaluate(exec),
             Expression::Capture(expr) => expr.evaluate(exec),
             Expression::Variable(expr) => expr.evaluate(exec),
             Expression::Call(expr) => expr.evaluate(exec),
@@ -618,7 +618,7 @@ impl StringConstant {
     }
 }
 
-impl ListComprehension {
+impl ListLiteral {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
         let elements = self
             .elements
@@ -629,7 +629,7 @@ impl ListComprehension {
     }
 }
 
-impl SetComprehension {
+impl SetLiteral {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
         let elements = self
             .elements

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 use anyhow::Context as ErrorContext;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use thiserror::Error;
 use tree_sitter::CaptureQuantifier;
@@ -31,11 +32,13 @@ use crate::ast::File;
 use crate::ast::ForIn;
 use crate::ast::If;
 use crate::ast::IntegerConstant;
+use crate::ast::ListComprehension;
 use crate::ast::ListLiteral;
 use crate::ast::Print;
 use crate::ast::RegexCapture;
 use crate::ast::Scan;
 use crate::ast::ScopedVariable;
+use crate::ast::SetComprehension;
 use crate::ast::SetLiteral;
 use crate::ast::Stanza;
 use crate::ast::Statement;
@@ -598,6 +601,8 @@ impl Expression {
             Expression::StringConstant(expr) => expr.evaluate(exec),
             Expression::ListLiteral(expr) => expr.evaluate(exec),
             Expression::SetLiteral(expr) => expr.evaluate(exec),
+            Expression::ListComprehension(expr) => expr.evaluate(exec),
+            Expression::SetComprehension(expr) => expr.evaluate(exec),
             Expression::Capture(expr) => expr.evaluate(exec),
             Expression::Variable(expr) => expr.evaluate(exec),
             Expression::Call(expr) => expr.evaluate(exec),
@@ -629,6 +634,32 @@ impl ListLiteral {
     }
 }
 
+impl ListComprehension {
+    fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
+        let values = self.value.evaluate(exec)?.into_list()?;
+        let mut elements = Vec::new();
+        let mut loop_locals = VariableMap::nested(exec.locals);
+        for value in values {
+            loop_locals.clear();
+            let mut loop_exec = ExecutionContext {
+                source: exec.source,
+                graph: exec.graph,
+                config: exec.config,
+                locals: &mut loop_locals,
+                scoped: exec.scoped,
+                current_regex_captures: exec.current_regex_captures,
+                function_parameters: exec.function_parameters,
+                mat: exec.mat,
+                shorthands: exec.shorthands,
+            };
+            self.variable.add(&mut loop_exec, value, false)?;
+            let element = self.element.evaluate(&mut loop_exec)?;
+            elements.push(element);
+        }
+        Ok(Value::List(elements))
+    }
+}
+
 impl SetLiteral {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
         let elements = self
@@ -636,6 +667,32 @@ impl SetLiteral {
             .iter()
             .map(|e| e.evaluate(exec))
             .collect::<Result<_, _>>()?;
+        Ok(Value::Set(elements))
+    }
+}
+
+impl SetComprehension {
+    fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
+        let values = self.value.evaluate(exec)?.into_list()?;
+        let mut elements = BTreeSet::new();
+        let mut loop_locals = VariableMap::nested(exec.locals);
+        for value in values {
+            loop_locals.clear();
+            let mut loop_exec = ExecutionContext {
+                source: exec.source,
+                graph: exec.graph,
+                config: exec.config,
+                locals: &mut loop_locals,
+                scoped: exec.scoped,
+                current_regex_captures: exec.current_regex_captures,
+                function_parameters: exec.function_parameters,
+                mat: exec.mat,
+                shorthands: exec.shorthands,
+            };
+            self.variable.add(&mut loop_exec, value, false)?;
+            let element = self.element.evaluate(&mut loop_exec)?;
+            elements.insert(element);
+        }
         Ok(Value::Set(elements))
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -474,6 +474,12 @@ impl From<Vec<Value>> for Value {
     }
 }
 
+impl From<BTreeSet<Value>> for Value {
+    fn from(value: BTreeSet<Value>) -> Value {
+        Value::Set(value)
+    }
+}
+
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -432,8 +432,8 @@ impl ast::Expression {
             Self::TrueLiteral => Ok(true.into()),
             Self::IntegerConstant(expr) => expr.evaluate_lazy(exec),
             Self::StringConstant(expr) => expr.evaluate_lazy(exec),
-            Self::List(expr) => expr.evaluate_lazy(exec),
-            Self::Set(expr) => expr.evaluate_lazy(exec),
+            Self::ListLiteral(expr) => expr.evaluate_lazy(exec),
+            Self::SetLiteral(expr) => expr.evaluate_lazy(exec),
             Self::Capture(expr) => expr.evaluate_lazy(exec),
             Self::Variable(expr) => expr.evaluate_lazy(exec),
             Self::Call(expr) => expr.evaluate_lazy(exec),
@@ -468,7 +468,7 @@ impl ast::StringConstant {
     }
 }
 
-impl ast::ListComprehension {
+impl ast::ListLiteral {
     fn evaluate_lazy(&self, exec: &mut ExecutionContext) -> Result<LazyValue, ExecutionError> {
         let mut elements = Vec::new();
         for element in &self.elements {
@@ -478,7 +478,7 @@ impl ast::ListComprehension {
     }
 }
 
-impl ast::SetComprehension {
+impl ast::SetLiteral {
     fn evaluate_lazy(&self, exec: &mut ExecutionContext) -> Result<LazyValue, ExecutionError> {
         let mut elements = Vec::new();
         for element in &self.elements {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -738,13 +738,10 @@ impl<'a> Parser<'a> {
             Ok(ast::ListLiteral { elements }.into())
         } else if let Ok(_) = self.consume_token(",") {
             self.consume_whitespace();
-            let other_elements = self.parse_sequence(']')?;
+            let mut elements = self.parse_sequence(']')?;
             self.consume_whitespace();
             self.consume_token("]")?;
-            let elements = vec![first_element]
-                .into_iter()
-                .chain(other_elements)
-                .collect();
+            elements.insert(0, first_element);
             Ok(ast::ListLiteral { elements }.into())
         } else {
             self.consume_token("for")?;
@@ -780,13 +777,10 @@ impl<'a> Parser<'a> {
             Ok(ast::SetLiteral { elements }.into())
         } else if let Ok(_) = self.consume_token(",") {
             self.consume_whitespace();
-            let other_elements = self.parse_sequence('}')?;
+            let mut elements = self.parse_sequence('}')?;
             self.consume_whitespace();
             self.consume_token("}")?;
-            let elements = vec![first_element]
-                .into_iter()
-                .chain(other_elements)
-                .collect();
+            elements.insert(0, first_element);
             Ok(ast::SetLiteral { elements }.into())
         } else {
             self.consume_token("for")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -729,7 +729,7 @@ impl<'a> Parser<'a> {
         self.consume_whitespace();
         let elements = self.parse_sequence(']')?;
         self.consume_token("]")?;
-        Ok(ast::ListComprehension { elements }.into())
+        Ok(ast::ListLiteral { elements }.into())
     }
 
     fn parse_set(&mut self) -> Result<ast::Expression, ParseError> {
@@ -737,7 +737,7 @@ impl<'a> Parser<'a> {
         self.consume_whitespace();
         let elements = self.parse_sequence('}')?;
         self.consume_token("}")?;
-        Ok(ast::SetComprehension { elements }.into())
+        Ok(ast::SetLiteral { elements }.into())
     }
 
     fn parse_capture(&mut self) -> Result<ast::Capture, ParseError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -725,19 +725,87 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_list(&mut self) -> Result<ast::Expression, ParseError> {
+        let location = self.location;
         self.consume_token("[")?;
         self.consume_whitespace();
-        let elements = self.parse_sequence(']')?;
-        self.consume_token("]")?;
-        Ok(ast::ListLiteral { elements }.into())
+        if let Ok(_) = self.consume_token("]") {
+            return Ok(ast::ListLiteral { elements: vec![] }.into());
+        }
+        let first_element = self.parse_expression()?;
+        self.consume_whitespace();
+        if let Ok(_) = self.consume_token("]") {
+            let elements = vec![first_element];
+            Ok(ast::ListLiteral { elements }.into())
+        } else if let Ok(_) = self.consume_token(",") {
+            self.consume_whitespace();
+            let other_elements = self.parse_sequence(']')?;
+            self.consume_whitespace();
+            self.consume_token("]")?;
+            let elements = vec![first_element]
+                .into_iter()
+                .chain(other_elements)
+                .collect();
+            Ok(ast::ListLiteral { elements }.into())
+        } else {
+            self.consume_token("for")?;
+            self.consume_whitespace();
+            let variable = self.parse_unscoped_variable()?;
+            self.consume_whitespace();
+            self.consume_token("in")?;
+            self.consume_whitespace();
+            let value = self.parse_expression()?;
+            self.consume_whitespace();
+            self.consume_token("]")?;
+            Ok(ast::ListComprehension {
+                element: first_element.into(),
+                variable,
+                value: value.into(),
+                location,
+            }
+            .into())
+        }
     }
 
     fn parse_set(&mut self) -> Result<ast::Expression, ParseError> {
+        let location = self.location;
         self.consume_token("{")?;
         self.consume_whitespace();
-        let elements = self.parse_sequence('}')?;
-        self.consume_token("}")?;
-        Ok(ast::SetLiteral { elements }.into())
+        if let Ok(_) = self.consume_token("}") {
+            return Ok(ast::SetLiteral { elements: vec![] }.into());
+        }
+        let first_element = self.parse_expression()?;
+        self.consume_whitespace();
+        if let Ok(_) = self.consume_token("}") {
+            let elements = vec![first_element];
+            Ok(ast::SetLiteral { elements }.into())
+        } else if let Ok(_) = self.consume_token(",") {
+            self.consume_whitespace();
+            let other_elements = self.parse_sequence('}')?;
+            self.consume_whitespace();
+            self.consume_token("}")?;
+            let elements = vec![first_element]
+                .into_iter()
+                .chain(other_elements)
+                .collect();
+            Ok(ast::SetLiteral { elements }.into())
+        } else {
+            self.consume_token("for")?;
+            self.consume_whitespace();
+            let variable = self.parse_unscoped_variable()?;
+            self.consume_whitespace();
+            self.consume_token("in")?;
+            self.consume_whitespace();
+            let value = self.parse_expression()?;
+            self.consume_whitespace();
+            self.consume_token("}")?;
+            Ok(ast::SetComprehension {
+                element: first_element.into(),
+                variable,
+                value: value.into(),
+                location,
+            }
+            .into())
+        }
     }
 
     fn parse_capture(&mut self) -> Result<ast::Capture, ParseError> {

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -126,7 +126,9 @@
 //!   - a reference to a syntax node
 //!   - a reference to a graph node
 //!   - an ordered list of values
+//!   - a list comprehension
 //!   - an unordered set of values
+//!   - a set comprehension
 //!
 //! The null value is spelled `#null`.
 //!
@@ -169,6 +171,25 @@
 //!   @id,
 //! ]
 //! ```
+//!
+//! List comprehensions allow mapping over a list and producing a new list with elements based on the
+//! given element expression:
+//!
+//! ``` tsg
+//! [ (some-function x) for x in @xs ]
+//! [ @x.scoped_var for x in @xs ]
+//! ```
+//!
+//! Set comprehensions have similar syntax, but the resulting value will be a set instead of an ordered list:
+//!
+//! ``` tsg
+//! { (some-function x) for x in @xs }
+//! { @x.scoped_var for x in @xs }
+//! ```
+//!
+//! List and set comprehensions are subject to the same restrictions as for loops, which means the list
+//! value that is iterated over must be local.  It is therefore not possible to iterator over the value
+//! of a scoped variable. Using scoped variables in the element expression however is no problem.
 //!
 //! # Syntax nodes
 //!

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -798,6 +798,50 @@ fn variables_are_inherited_in_for_in_body() {
 }
 
 #[test]
+fn can_execute_list_comprehension() {
+    check_execution(
+        r#"
+          pass
+          pass
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)* @xs) @root
+          {
+            node node0
+            attr (node0) val = [ (named-child-index x) for x in @xs ]
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: [0, 1, 2]
+        "#},
+    );
+}
+
+#[test]
+fn can_execute_set_comprehension() {
+    check_execution(
+        r#"
+          pass
+          pass
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)* @xs) @root
+          {
+            node node0
+            attr (node0) val = { (source-text x) for x in @xs }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: {"pass"}
+        "#},
+    );
+}
+
+#[test]
 fn can_execute_scan_of_local_call_expression() {
     check_execution(
         r#"

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -794,6 +794,50 @@ fn variables_are_inherited_in_for_in_body() {
 }
 
 #[test]
+fn can_execute_list_comprehension() {
+    check_execution(
+        r#"
+          pass
+          pass
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)* @xs) @root
+          {
+            node node0
+            attr (node0) val = [ (named-child-index x) for x in @xs ]
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: [0, 1, 2]
+        "#},
+    );
+}
+
+#[test]
+fn can_execute_set_comprehension() {
+    check_execution(
+        r#"
+          pass
+          pass
+          pass
+        "#,
+        indoc! {r#"
+          (module (pass_statement)* @xs) @root
+          {
+            node node0
+            attr (node0) val = { (source-text x) for x in @xs }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            val: {"pass"}
+        "#},
+    );
+}
+
+#[test]
 fn can_execute_scan_of_local_call_expression() {
     check_execution(
         r#"

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -337,7 +337,7 @@ fn can_parse_lists() {
                     location: Location { row: 3, column: 14 }
                 }
                 .into(),
-                value: ListComprehension {
+                value: ListLiteral {
                     elements: vec![
                         IntegerConstant { value: 1 }.into(),
                         IntegerConstant { value: 2 }.into(),
@@ -354,7 +354,7 @@ fn can_parse_lists() {
                     location: Location { row: 4, column: 14 }
                 }
                 .into(),
-                value: ListComprehension { elements: vec![] }.into(),
+                value: ListLiteral { elements: vec![] }.into(),
                 location: Location { row: 4, column: 10 },
             }
             .into(),
@@ -364,7 +364,7 @@ fn can_parse_lists() {
                     location: Location { row: 5, column: 14 }
                 }
                 .into(),
-                value: ListComprehension {
+                value: ListLiteral {
                     elements: vec![
                         StringConstant {
                             value: String::from("hello")
@@ -414,7 +414,7 @@ fn can_parse_sets() {
                     location: Location { row: 3, column: 14 }
                 }
                 .into(),
-                value: SetComprehension {
+                value: SetLiteral {
                     elements: vec![
                         IntegerConstant { value: 1 }.into(),
                         IntegerConstant { value: 2 }.into(),
@@ -431,7 +431,7 @@ fn can_parse_sets() {
                     location: Location { row: 4, column: 14 }
                 }
                 .into(),
-                value: SetComprehension { elements: vec![] }.into(),
+                value: SetLiteral { elements: vec![] }.into(),
                 location: Location { row: 4, column: 10 },
             }
             .into(),
@@ -441,7 +441,7 @@ fn can_parse_sets() {
                     location: Location { row: 5, column: 14 }
                 }
                 .into(),
-                value: SetComprehension {
+                value: SetLiteral {
                     elements: vec![
                         StringConstant {
                             value: String::from("hello")

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -1076,6 +1076,112 @@ fn cannot_parse_scan_of_nonlocal_variable() {
 }
 
 #[test]
+fn can_parse_list_comprehension() {
+    let source = r#"
+        (module (_)* @xs)@mod
+        {
+          print [ (named-child-index x) for x in @xs ]
+        }
+    "#;
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
+
+    let statements = file
+        .stanzas
+        .into_iter()
+        .map(|s| s.statements)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        statements,
+        vec![vec![Print {
+            values: vec![ListComprehension {
+                element: Box::new(
+                    Call {
+                        function: "named-child-index".into(),
+                        parameters: vec![UnscopedVariable {
+                            name: "x".into(),
+                            location: Location { row: 3, column: 37 }
+                        }
+                        .into()]
+                    }
+                    .into()
+                ),
+                variable: UnscopedVariable {
+                    name: "x".into(),
+                    location: Location { row: 3, column: 44 }
+                },
+                value: Box::new(
+                    Capture {
+                        name: "xs".into(),
+                        quantifier: ZeroOrMore,
+                        file_capture_index: 0,
+                        stanza_capture_index: 0,
+                        location: Location { row: 3, column: 49 }
+                    }
+                    .into()
+                ),
+                location: Location { row: 3, column: 16 }
+            }
+            .into()],
+            location: Location { row: 3, column: 10 }
+        }
+        .into()]]
+    );
+}
+
+#[test]
+fn can_parse_set_comprehension() {
+    let source = r#"
+        (module (_)* @xs)@mod
+        {
+          print { (named-child-index x) for x in @xs }
+        }
+    "#;
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
+
+    let statements = file
+        .stanzas
+        .into_iter()
+        .map(|s| s.statements)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        statements,
+        vec![vec![Print {
+            values: vec![SetComprehension {
+                element: Box::new(
+                    Call {
+                        function: "named-child-index".into(),
+                        parameters: vec![UnscopedVariable {
+                            name: "x".into(),
+                            location: Location { row: 3, column: 37 }
+                        }
+                        .into()]
+                    }
+                    .into()
+                ),
+                variable: UnscopedVariable {
+                    name: "x".into(),
+                    location: Location { row: 3, column: 44 }
+                },
+                value: Box::new(
+                    Capture {
+                        name: "xs".into(),
+                        quantifier: ZeroOrMore,
+                        file_capture_index: 0,
+                        stanza_capture_index: 0,
+                        location: Location { row: 3, column: 49 }
+                    }
+                    .into()
+                ),
+                location: Location { row: 3, column: 16 }
+            }
+            .into()],
+            location: Location { row: 3, column: 10 }
+        }
+        .into()]]
+    );
+}
+
+#[test]
 fn can_parse_global() {
     let source = r#"
         global root


### PR DESCRIPTION
This adds support for list comprehensions. At the moment it is very cumbersome to get the values of scoped variables for a list of nodes, or the source text of such a list. This allows you to write that down nicely without having to jump through hoops with mutable variables and functions:

```
(parameters (_)* @names)@params {
  let @params.names = [ (source-next name for name in @names ]
}
```

The comprehensions are subject to the same locality restrictions as for loops, so they don't make the language more powerful, just more convenient.

_Can be reviews commit-by-commit_