### PR TITLE
Add `TreeWithParseError*` types to safely move tree and parse errors

### DIFF
--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -86,7 +86,14 @@ fn main() -> Result<()> {
         let parse_errors = ParseError::all(&tree);
         if !parse_errors.is_empty() {
             for parse_error in parse_errors.iter().take(MAX_PARSE_ERRORS) {
-                eprintln!("{}", parse_error.display(&source, true));
+                let line = parse_error.node().start_position().row;
+                let column = parse_error.node().start_position().column;
+                eprintln!(
+                    "On line {} column {}: {}",
+                    line + 1,
+                    column + 1,
+                    parse_error.display(&source, true)
+                );
             }
             if parse_errors.len() > MAX_PARSE_ERRORS {
                 let more_errors = parse_errors.len() - MAX_PARSE_ERRORS;

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -89,7 +89,8 @@ fn main() -> Result<()> {
                 let line = parse_error.node().start_position().row;
                 let column = parse_error.node().start_position().column;
                 eprintln!(
-                    "On line {} column {}: {}",
+                    "{}:{}:{}: {}",
+                    source_path.display(),
                     line + 1,
                     column + 1,
                     parse_error.display(&source, true)

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -83,15 +83,17 @@ fn main() -> Result<()> {
         .ok_or_else(|| anyhow!("Cannot parse {}", source_path.display()))?;
     let allow_parse_errors = matches.is_present("allow-parse-errors");
     if !allow_parse_errors {
-        let parse_errors = ParseError::find_all(&tree);
+        let parse_errors = ParseError::all(&tree);
         if !parse_errors.is_empty() {
             for parse_error in parse_errors.iter().take(MAX_PARSE_ERRORS) {
                 eprintln!("{}", parse_error.display(&source, true));
             }
             if parse_errors.len() > MAX_PARSE_ERRORS {
+                let more_errors = parse_errors.len() - MAX_PARSE_ERRORS;
                 eprintln!(
-                    "{} more parse errors omitted",
-                    parse_errors.len() - MAX_PARSE_ERRORS
+                    "{} more parse error{} omitted",
+                    more_errors,
+                    if more_errors > 1 { "s" } else { "" },
                 );
             }
             return Err(anyhow!("Cannot parse {}", source_path.display()));

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -52,6 +52,13 @@ impl<'tree> ParseError<'tree> {
 }
 
 impl<'tree> ParseError<'tree> {
+    pub fn node(&self) -> &Node<'tree> {
+        match self {
+            Self::Missing(node) => node,
+            Self::Unexpected(node) => node,
+        }
+    }
+
     pub fn display(&self, source: &'tree str, verbose: bool) -> ParseErrorDisplay {
         ParseErrorDisplay {
             error: self,
@@ -81,7 +88,6 @@ impl std::fmt::Display for ParseErrorDisplay<'_> {
         };
         let line = node.start_position().row;
         let start_column = node.start_position().column;
-        write!(f, " on line {} column {}", line + 1, start_column + 1)?;
         if node.byte_range().is_empty() {
             writeln!(f, "")?;
         } else {

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -8,7 +8,7 @@
 use tree_sitter::Node;
 use tree_sitter::Tree;
 
-/// Parse errors for tree-sitter parse tree
+/// Parse error for tree-sitter tree
 #[derive(Debug)]
 pub enum ParseError<'tree> {
     /// Error representing missing syntax
@@ -18,63 +18,41 @@ pub enum ParseError<'tree> {
 }
 
 impl<'tree> ParseError<'tree> {
-    pub fn find_first(tree: &'tree Tree) -> Option<ParseError> {
+    /// Return the first parse error in the given tree, if it exists.
+    pub fn first(tree: &Tree) -> Option<ParseError> {
         let mut errors = Vec::new();
-        Self::find_into(tree, &mut errors, true);
+        find_errors(tree, &mut errors, true);
         errors.into_iter().next()
     }
 
-    pub fn find_all(tree: &'tree Tree) -> Vec<ParseError> {
+    /// Return the tree and the first parse error in the given tree, if it exists.
+    /// This returns a type, combining the tree and the error, that can be moved safely,
+    /// which is not possible with a seperate tree and error.
+    pub fn into_first(tree: Tree) -> TreeWithParseErrorOption {
         let mut errors = Vec::new();
-        Self::find_into(tree, &mut errors, true);
+        find_errors(&tree, &mut errors, true);
+        crate::new_tree_with_parse_error_option!(tree, errors.into_iter().next())
+    }
+
+    /// Return all parse errors in the given tree.
+    pub fn all(tree: &'tree Tree) -> Vec<ParseError> {
+        let mut errors = Vec::new();
+        find_errors(tree, &mut errors, false);
         errors
     }
 
-    fn find_into(tree: &'tree Tree, errors: &mut Vec<ParseError<'tree>>, first_only: bool) {
-        // do not walk the tree unless there actually are errors
-        if !tree.root_node().has_error() {
-            return;
-        }
-
-        let mut cursor = tree.walk();
-        let mut did_visit_children = false;
-        loop {
-            let node = cursor.node();
-            if node.is_error() {
-                errors.push(ParseError::Unexpected(node));
-                if first_only {
-                    break;
-                }
-                did_visit_children = true;
-            } else if node.is_missing() {
-                errors.push(ParseError::Missing(node));
-                if first_only {
-                    break;
-                }
-                did_visit_children = true;
-            }
-            if did_visit_children {
-                if cursor.goto_next_sibling() {
-                    did_visit_children = false;
-                } else if cursor.goto_parent() {
-                    did_visit_children = true;
-                } else {
-                    break;
-                }
-            } else {
-                if cursor.goto_first_child() {
-                    did_visit_children = false;
-                } else {
-                    did_visit_children = true;
-                }
-            }
-        }
-        cursor.reset(tree.root_node());
+    /// Return the tree and all parse errors in the given tree.
+    /// This returns a type, combining the tree and the errors, that can be moved safely,
+    /// which is not possible with a seperate tree and errors.
+    pub fn into_all(tree: Tree) -> TreeWithParseErrorVec {
+        let mut errors = Vec::new();
+        find_errors(&tree, &mut errors, false);
+        crate::new_tree_with_parse_error_vec!(tree, errors)
     }
 }
 
 impl<'tree> ParseError<'tree> {
-    pub fn display(&'tree self, source: &'tree str, verbose: bool) -> ParseErrorDisplay<'tree> {
+    pub fn display(&self, source: &'tree str, verbose: bool) -> ParseErrorDisplay {
         ParseErrorDisplay {
             error: self,
             source,
@@ -138,3 +116,195 @@ impl std::fmt::Display for ParseErrorDisplay<'_> {
         Ok(())
     }
 }
+
+/// Find errors in the given tree and add those to the given errors vector
+fn find_errors<'tree>(tree: &'tree Tree, errors: &mut Vec<ParseError<'tree>>, first_only: bool) {
+    // do not walk the tree unless there actually are errors
+    if !tree.root_node().has_error() {
+        return;
+    }
+
+    let mut cursor = tree.walk();
+    let mut did_visit_children = false;
+    loop {
+        let node = cursor.node();
+        if node.is_error() {
+            errors.push(ParseError::Unexpected(node));
+            if first_only {
+                break;
+            }
+            did_visit_children = true;
+        } else if node.is_missing() {
+            errors.push(ParseError::Missing(node));
+            if first_only {
+                break;
+            }
+            did_visit_children = true;
+        }
+        if did_visit_children {
+            if cursor.goto_next_sibling() {
+                did_visit_children = false;
+            } else if cursor.goto_parent() {
+                did_visit_children = true;
+            } else {
+                break;
+            }
+        } else {
+            if cursor.goto_first_child() {
+                did_visit_children = false;
+            } else {
+                did_visit_children = true;
+            }
+        }
+    }
+    cursor.reset(tree.root_node());
+}
+
+// ------------------------------------------------------------------------------------------------
+// Types to package a tree and parse errors for that tree
+//
+// Parse errors contain `Node` values, that are parametrized by the lifetime `tree of the tree they
+// are part of. It is normally not possible to combine a value and references to that value in a single
+// data type. However, in the case of tree-sitter trees and nodes, the nodes do not point to memory in the
+// tree value, but both point to heap allocated memory. Therefore, moving the tree does not invalidate the
+// node. We use this fact to implement the TreeWithParseError* types.
+//
+// To be able to use these types in errors, we implement Send and Sync. These traits are implemented for
+// Tree, but not for Node. However, since the TreeWithParseError* types contain the tree as well as the nodes,
+// it is okay to implement Send and Sync.
+
+/// A type containing a tree and a parse error
+pub struct TreeWithParseError {
+    tree: Tree,
+    // the 'static lifetime is okay because we own `tree`
+    error: ParseError<'static>,
+}
+
+#[macro_export]
+macro_rules! new_tree_with_parse_error {
+    ($tree:expr,$error:expr) => {{
+        TreeWithParseError {
+            error: unsafe { std::mem::transmute($error) },
+            tree: $tree,
+        }
+    }};
+}
+
+impl TreeWithParseError {
+    pub fn tree(&self) -> &Tree {
+        &self.tree
+    }
+
+    pub fn into_tree(self) -> Tree {
+        self.tree
+    }
+
+    pub fn error(&self) -> &ParseError {
+        &self.error
+    }
+}
+
+impl std::fmt::Debug for TreeWithParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self.error)
+    }
+}
+
+// Send and Sync must be implemented for ParseError -> Node -> ffi::TSTree
+// This is okay because Send and Sync _are_ implemented for Tree, which also holds ffi::TSTree
+unsafe impl Send for TreeWithParseError {}
+unsafe impl Sync for TreeWithParseError {}
+
+/// A type containing a tree and an optional parse error
+pub struct TreeWithParseErrorOption {
+    tree: Tree,
+    // the 'static lifetime is okay because we own `tree`
+    error: Option<ParseError<'static>>,
+}
+
+#[macro_export]
+macro_rules! new_tree_with_parse_error_option {
+    ($tree:expr,$error:expr) => {{
+        TreeWithParseErrorOption {
+            error: unsafe { std::mem::transmute($error) },
+            tree: $tree,
+        }
+    }};
+}
+
+impl TreeWithParseErrorOption {
+    pub fn tree(&self) -> &Tree {
+        &self.tree
+    }
+
+    pub fn into_tree(self) -> Tree {
+        self.tree
+    }
+
+    pub fn error(&self) -> &Option<ParseError> {
+        &self.error
+    }
+
+    pub fn into_option(self) -> Option<TreeWithParseError> {
+        match self.error {
+            None => None,
+            Some(error) => Some(TreeWithParseError {
+                tree: self.tree,
+                error,
+            }),
+        }
+    }
+}
+
+impl std::fmt::Debug for TreeWithParseErrorOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self.error)
+    }
+}
+
+// Send and Sync must be implemented for ParseError -> Node -> ffi::TSTree
+// This is okay because Send and Sync _are_ implemented for Tree, which also holds ffi::TSTree
+unsafe impl Send for TreeWithParseErrorOption {}
+unsafe impl Sync for TreeWithParseErrorOption {}
+
+/// A type containing a tree and parse errors
+pub struct TreeWithParseErrorVec {
+    tree: Tree,
+    // the 'static lifetime is okay because we own `tree`
+    errors: Vec<ParseError<'static>>,
+}
+
+#[macro_export]
+macro_rules! new_tree_with_parse_error_vec {
+    ($tree:expr,$errors:expr) => {{
+        TreeWithParseErrorVec {
+            errors: unsafe { std::mem::transmute($errors) },
+            tree: $tree,
+        }
+    }};
+}
+
+impl TreeWithParseErrorVec {
+    pub fn tree(&self) -> &Tree {
+        &self.tree
+    }
+
+    pub fn into_tree(self) -> Tree {
+        self.tree
+    }
+
+    pub fn errors(&self) -> &Vec<ParseError> {
+        &self.errors
+    }
+}
+
+impl std::fmt::Debug for TreeWithParseErrorVec {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self.errors)
+    }
+}
+
+// Send and Sync must be implemented for ParseError -> Node -> ffi::TSTree
+// This is okay because Send and Sync _are_ implemented for Tree, which also holds ffi::TSTree
+unsafe impl Send for TreeWithParseErrorVec {}
+unsafe impl Sync for TreeWithParseErrorVec {}

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -5,6 +5,8 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+//! Data types and functions for finding and displaying tree-sitter parse errors.
+
 use tree_sitter::Node;
 use tree_sitter::Tree;
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -8,4 +8,5 @@
 mod execution;
 mod graph;
 mod lazy_execution;
+mod parse_errors;
 mod parser;

--- a/tests/it/parse_errors.rs
+++ b/tests/it/parse_errors.rs
@@ -1,0 +1,94 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2022, tree-sitter authors.
+// Licensed under either of Apache License, Version 2.0, or MIT license, at your option.
+// Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
+// ------------------------------------------------------------------------------------------------
+
+use indoc::indoc;
+use tree_sitter::Parser;
+use tree_sitter::Point;
+use tree_sitter::Tree;
+use tree_sitter_graph::parse_error::ParseError;
+
+fn init_log() {
+    let _ = env_logger::builder()
+        .is_test(true)
+        .format_level(false)
+        .format_target(false)
+        .format_timestamp(None)
+        .try_init(); // try, because earlier test may have already initialized it
+}
+
+fn parse(python_source: &str) -> Tree {
+    init_log();
+    let mut parser = Parser::new();
+    parser.set_language(tree_sitter_python::language()).unwrap();
+    parser.parse(python_source, None).unwrap()
+}
+
+#[test]
+fn can_find_error() {
+    let tree = parse(indoc! {r#"
+        def f():
+            a 42
+        def g():
+            pass
+    "#});
+    let parse_error = ParseError::first(&tree);
+    let position = parse_error.map(|e| e.node().start_position());
+    assert_eq!(position, Some(Point::new(1, 4)));
+}
+
+#[test]
+fn can_find_errors() {
+    let tree = parse(indoc! {r#"
+        def f():
+            a 42
+        def g():
+            b 11
+    "#});
+    let parse_errors = ParseError::all(&tree);
+    let positions = parse_errors
+        .into_iter()
+        .map(|e| e.node().start_position())
+        .collect::<Vec<_>>();
+    assert_eq!(positions, vec![Point::new(1, 4), Point::new(3, 4)]);
+}
+
+#[test]
+fn can_move_tree_with_error() {
+    let tree = parse(indoc! {r#"
+        def f():
+            a 42
+        def g():
+            pass
+    "#});
+    let parse_error = ParseError::into_first(tree);
+    let moved_parse_error = parse_error;
+    let position = moved_parse_error
+        .error()
+        .as_ref()
+        .map(|e| e.node().start_position());
+    assert_eq!(position, Some(Point::new(1, 4)));
+    let _recovered_tree = moved_parse_error.into_tree();
+}
+
+#[test]
+fn can_move_tree_with_errors() {
+    let tree = parse(indoc! {r#"
+        def f():
+            a 42
+        def g():
+            b 11
+    "#});
+    let parse_errors = ParseError::into_all(tree);
+    let moved_parse_errors = parse_errors;
+    let positions = moved_parse_errors
+        .errors()
+        .iter()
+        .map(|e| e.node().start_position())
+        .collect::<Vec<_>>();
+    assert_eq!(positions, vec![Point::new(1, 4), Point::new(3, 4)]);
+    let _recovered_tree = moved_parse_errors.into_tree();
+}


### PR DESCRIPTION
**The implementation uses `unsafe` code, so careful review is appreciated.**

1. This adds types that allow safely moving a `Tree` and `ParseError`s (which contain `Node<'tree>` references) together. This is normally not possible in Rust because moving the `Tree` would invalidate the references, but in the case of tree-sitter, the references point not to the Rust value, but to C allocated memory. This memory is not moved when the `Tree` is, and thus the references remain valid.

   The `TreeWithParseError*` types use `unsafe` code to erase the lifetime `'tree` to `static`. The `Tree` is owned by the value, and is only dropped when the value is. When the `Tree` is dropped, the memory is deallocated, so the parse errors should not outlive the `Tree`. This is ensured because the parse errors are only available through a reference, which cannot outlive the value they are tied to (which is the `TreeWithParseError*` that ownes the corresponding `Tree`).

2. The parse error formatting has been changed to _not_ include the position of the error. This gives the user more flexibility in how that should be formatted. E.g., in a UI, the position may not even be included in the message, or a tool may use a particular formatting convention for source positions.

_Can be reviewed commit-by-commit._