### PR TITLE
Serialize integers/node/graph IDs & lists/sets distinctly

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -529,7 +529,12 @@ impl Serialize for Value {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
             Value::Null => serializer.serialize_none(),
-            Value::Boolean(value) => serializer.serialize_bool(*value),
+            Value::Boolean(bool) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "bool")?;
+                map.serialize_entry("bool", bool)?;
+                map.end()
+            }
             Value::Integer(int) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "int")?;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -530,7 +530,12 @@ impl Serialize for Value {
         match self {
             Value::Null => serializer.serialize_none(),
             Value::Boolean(value) => serializer.serialize_bool(*value),
-            Value::Integer(value) => serializer.serialize_u32(*value),
+            Value::Integer(int) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "int")?;
+                map.serialize_entry("int", int)?;
+                map.end()
+            }
             Value::String(str) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "string")?;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -547,13 +547,13 @@ impl Serialize for Value {
             Value::SyntaxNode(node) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "syntaxNode")?;
-                map.serialize_entry("value", &node.index)?;
+                map.serialize_entry("id", &node.index)?;
                 map.end()
             }
             Value::GraphNode(node) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "graphNode")?;
-                map.serialize_entry("value", &node.0)?;
+                map.serialize_entry("id", &node.0)?;
                 map.end()
             }
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -532,7 +532,6 @@ impl Serialize for Value {
             Value::Boolean(value) => serializer.serialize_bool(*value),
             Value::Integer(value) => serializer.serialize_u32(*value),
             Value::String(value) => serializer.serialize_str(value),
-            // FIXME: there's no way to distinguish sets and lists, so we can't roundtrip accurately
             Value::List(list) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "list")?;
@@ -545,7 +544,6 @@ impl Serialize for Value {
                 map.serialize_entry("value", set)?;
                 map.end()
             }
-            // FIXME: we don't distinguish between syntax tree node IDs, graph node IDs, and integers
             Value::SyntaxNode(node) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "syntaxNode")?;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -546,7 +546,12 @@ impl Serialize for Value {
                 map.end()
             }
             // FIXME: we don't distinguish between syntax tree node IDs, graph node IDs, and integers
-            Value::SyntaxNode(node) => serializer.serialize_u32(node.index),
+            Value::SyntaxNode(node) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "syntaxNode")?;
+                map.serialize_entry("value", &node.index)?;
+                map.end()
+            }
             Value::GraphNode(node) => serializer.serialize_u32(node.0),
         }
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -539,7 +539,12 @@ impl Serialize for Value {
                 map.serialize_entry("value", list)?;
                 map.end()
             }
-            Value::Set(set) => serializer.collect_seq(set),
+            Value::Set(set) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "set")?;
+                map.serialize_entry("value", set)?;
+                map.end()
+            }
             // FIXME: we don't distinguish between syntax tree node IDs, graph node IDs, and integers
             Value::SyntaxNode(node) => serializer.serialize_u32(node.index),
             Value::GraphNode(node) => serializer.serialize_u32(node.0),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -531,7 +531,12 @@ impl Serialize for Value {
             Value::Null => serializer.serialize_none(),
             Value::Boolean(value) => serializer.serialize_bool(*value),
             Value::Integer(value) => serializer.serialize_u32(*value),
-            Value::String(value) => serializer.serialize_str(value),
+            Value::String(str) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "string")?;
+                map.serialize_entry("string", str)?;
+                map.end()
+            }
             Value::List(list) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "list")?;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -206,7 +206,7 @@ impl<'a> Serialize for SerializeGraphNode<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("id", &node_index)?;
         map.serialize_entry("edges", &SerializeGraphNodeEdges(&node.outgoing_edges))?;
-        map.serialize_entry("attrs", &SerializeGraphNodeAttributes(&node.attributes))?;
+        map.serialize_entry("attrs", &node.attributes)?;
         map.end()
     }
 }
@@ -234,18 +234,6 @@ impl<'a> Serialize for SerializeGraphNodeEdge<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("sink", sink)?;
         map.serialize_entry("attrs", &edge.attributes)?;
-        map.end()
-    }
-}
-
-struct SerializeGraphNodeAttributes<'a>(&'a Attributes);
-
-impl<'a> Serialize for SerializeGraphNodeAttributes<'a> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        for (key, value) in &self.0.values {
-            map.serialize_entry(key, value)?;
-        }
         map.end()
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -533,7 +533,12 @@ impl Serialize for Value {
             Value::Integer(value) => serializer.serialize_u32(*value),
             Value::String(value) => serializer.serialize_str(value),
             // FIXME: there's no way to distinguish sets and lists, so we can't roundtrip accurately
-            Value::List(list) => serializer.collect_seq(list),
+            Value::List(list) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "list")?;
+                map.serialize_entry("value", list)?;
+                map.end()
+            }
             Value::Set(set) => serializer.collect_seq(set),
             // FIXME: we don't distinguish between syntax tree node IDs, graph node IDs, and integers
             Value::SyntaxNode(node) => serializer.serialize_u32(node.index),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -528,7 +528,11 @@ impl std::fmt::Display for Value {
 impl Serialize for Value {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
-            Value::Null => serializer.serialize_none(),
+            Value::Null => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "null")?;
+                map.end()
+            }
             Value::Boolean(bool) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "bool")?;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -535,13 +535,13 @@ impl Serialize for Value {
             Value::List(list) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "list")?;
-                map.serialize_entry("value", list)?;
+                map.serialize_entry("values", list)?;
                 map.end()
             }
             Value::Set(set) => {
                 let mut map = serializer.serialize_map(None)?;
                 map.serialize_entry("type", "set")?;
-                map.serialize_entry("value", set)?;
+                map.serialize_entry("values", set)?;
                 map.end()
             }
             Value::SyntaxNode(node) => {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -206,7 +206,7 @@ impl<'a> Serialize for SerializeGraphNode<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("id", &node_index)?;
         map.serialize_entry("edges", &SerializeGraphNodeEdges(&node.outgoing_edges))?;
-        map.serialize_entry("attrs", &node.attributes)?;
+        map.serialize_entry("attrs", &SerializeGraphNodeAttributes(&node.attributes))?;
         map.end()
     }
 }
@@ -234,6 +234,18 @@ impl<'a> Serialize for SerializeGraphNodeEdge<'a> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("sink", sink)?;
         map.serialize_entry("attrs", &edge.attributes)?;
+        map.end()
+    }
+}
+
+struct SerializeGraphNodeAttributes<'a>(&'a Attributes);
+
+impl<'a> Serialize for SerializeGraphNodeAttributes<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        for (key, value) in &self.0.values {
+            map.serialize_entry(key, value)?;
+        }
         map.end()
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -552,7 +552,12 @@ impl Serialize for Value {
                 map.serialize_entry("value", &node.index)?;
                 map.end()
             }
-            Value::GraphNode(node) => serializer.serialize_u32(node.0),
+            Value::GraphNode(node) => {
+                let mut map = serializer.serialize_map(None)?;
+                map.serialize_entry("type", "graphNode")?;
+                map.serialize_entry("value", &node.0)?;
+                map.end()
+            }
         }
     }
 }


### PR DESCRIPTION
- [x] Fixes #46.
- [x] Does the same for lists/sets.