### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.5.0 -- 2022-05-09
 
 ### DSL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Report query errors with correct source locations.
 
+### Library
+
+#### Changed
+
+- In JSON output, all values are represented as objects with a `type` field
+  indicating the value type, and additional value fields that vary per type.
+
+### CLI
+
+#### Added
+
+- Flag `--output`/`-o` to set JSON output path.
+
 ## 0.4.0 -- 2022-03-21
 
 ### DSL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### DSL
+
+#### Fixed
+
+- Report query errors with correct source locations.
+
 ## 0.4.0 -- 2022-03-21
 
 ### DSL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.4.0"
+version = "0.5.0"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use it as a library, add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
-tree-sitter-graph = "0.4"
+tree-sitter-graph = "0.5"
 ```
 
 To use it as a program, install it via `cargo install`:


### PR DESCRIPTION
I would like to release this so I can include the error reporting fix in `tree-sitter-stack-graphs`.
Since the JSON output changed, I think it's best to bump to 0.5 instead of 0.4.1.
