### PR TITLE
Add VS Code extension for tree-sitter-graph syntax

### DIFF
--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,0 +1,4 @@
+/node_modules/
+/.vscode/
+/.vscode-test/
+*.vsix

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -1,0 +1,4 @@
+node_modules/**
+.vscode/**
+.vscode-test/**
+.gitignore

--- a/vscode/LICENSE
+++ b/vscode/LICENSE
@@ -1,0 +1,1 @@
+Apache-2.0 OR MIT

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,0 +1,3 @@
+# tree-sitter-graph support for VS Code
+
+This language extension for VS Code provides syntax support for tree-sitter-graph files.

--- a/vscode/language-configuration.json
+++ b/vscode/language-configuration.json
@@ -1,0 +1,25 @@
+{
+    "comments": {
+        "lineComment": ";"
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""]
+    ],
+    // symbols that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""]
+    ]
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "tree-sitter-graph",
+    "version": "0.1.0",
+    "publisher": "tree-sitter",
+    "engines": {
+        "vscode": "^1.60.0"
+    },
+    "license": "Apache-2.0 OR MIT",
+    "description": "Syntax support for tree-sitter-graph",
+    "homepage": "https://crates.io/crates/tree-sitter-graph",
+    "author": "tree-sitter authors",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/tree-sitter/tree-sitter-graph.git"
+    },
+    "categories": [
+        "Programming Languages"
+    ],
+    "contributes": {
+        "languages": [
+            {
+                "id": "tree-sitter-graph",
+                "extensions": [
+                    ".tsg"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "tree-sitter-graph",
+                "scopeName": "source.tsg",
+                "path": "./syntaxes/tree-sitter-graph.tmLanguage.json"
+            }
+        ]
+    }
+}

--- a/vscode/syntaxes/tree-sitter-graph.tmLanguage.json
+++ b/vscode/syntaxes/tree-sitter-graph.tmLanguage.json
@@ -1,0 +1,52 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Tree-Sitter Graph",
+	"patterns": [{
+		"include": "#keywords"
+	}, {
+		"include": "#functions"
+	}, {
+		"include": "#constants"
+	}, {
+		"include": "#strings"
+	}, {
+		"include": "#comments"
+	}],
+	"repository": {
+		"keywords": {
+			"patterns": [{
+				"name": "keyword.control.tsg",
+				"match": "^\\s*(attr|attribute|edge|for|global|if|let|node|none|print|scan|set|some|var)\\b"
+			}]
+		},
+		"functions": {
+			"patterns": [{
+				"name": "support.function.tsg",
+				"match":"(?<=\\(\\s*)(and|end-column|end-row|is-empty|is-null|length|named-child-count|named-child-index|node|node-type|not|or|plus|replace|source-text|start-column|start-row)\\b"
+			}]
+		},
+		"constants": {
+			"patterns": [{
+				"name": "constant.language.tsg",
+				"match": "\\b(#false|#nil|#true)\\b"
+			}]
+		},
+		"strings": {
+			"name": "string.quoted.double.tsg",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [{
+				"name": "constant.character.escape.tsg",
+				"match": "\\\\."
+			}]
+		},
+		"comments": {
+			"patterns": [{
+				"name": "comment.line.semicolon.tsg",
+				"begin": ";",
+				"end": "$"
+			}]
+		}
+	},
+	"scopeName": "source.tsg"
+}


### PR DESCRIPTION
This adds a VS Code extension to provide syntax highlighting for tree-sitter-graph files.

Here's an impression (the exact colors are not determined by this extension, but, I suppose, by my VS Code theme):

![image](https://user-images.githubusercontent.com/999073/167670399-a0c47b07-57ef-470d-a364-09b09ada3581.png)

I would also like to publish this in the VS Code Marketplace.