### PR TITLE
Reject queries with multiple patterns

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,6 +70,8 @@ pub enum ParseError {
     UnexpectedKeyword(String, Location),
     #[error("Unexpected literal '#{0}' at {1}")]
     UnexpectedLiteral(String, Location),
+    #[error("Query contains multiple patterns {0}")]
+    UnexpectedQueryPatterns(Location),
     #[error(transparent)]
     Check(#[from] crate::checker::CheckError),
     #[error(transparent)]
@@ -305,6 +307,9 @@ impl<'a> Parser<'a> {
             e.offset += query_start;
             e
         })?;
+        if query.pattern_count() > 1 {
+            return Err(ParseError::UnexpectedQueryPatterns(location));
+        }
         Ok(query)
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,7 +70,7 @@ pub enum ParseError {
     UnexpectedKeyword(String, Location),
     #[error("Unexpected literal '#{0}' at {1}")]
     UnexpectedLiteral(String, Location),
-    #[error("Query contains multiple patterns {0}")]
+    #[error("Query contains multiple patterns at {0}")]
     UnexpectedQueryPatterns(Location),
     #[error(transparent)]
     Check(#[from] crate::checker::CheckError),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -60,8 +60,6 @@ pub enum ParseError {
     InvalidRegex(String, Location),
     #[error("Expected integer constant in regex capture at {0}")]
     InvalidRegexCapture(Location),
-    // TODO: The positions in the wrapped QueryError will be incorrect, since they will count the
-    // row/column from the start of the query, not from the start of the file.
     #[error("Invalid query pattern: {}", _0.message)]
     QueryError(#[from] QueryError),
     #[error("Unexpected character '{0}' in {1} at {2}")]

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -1519,3 +1519,16 @@ fn can_parse_shorthand() {
         }]
     );
 }
+
+#[test]
+fn cannot_parse_multiple_patterns() {
+    let source = r#"
+        (function_definition)
+        (pass_statement)
+        {
+        }
+    "#;
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
+        panic!("Parse succeeded unexpectedly");
+    }
+}


### PR DESCRIPTION
Add check that a query contains only one pattern.

Fixes #62.
