### PR TITLE
Add location where scoped variable was set to error message

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -777,7 +777,7 @@ impl ScopedVariable {
             Value::SyntaxNode(scope) => scope,
             _ => {
                 return Err(ExecutionError::InvalidVariableScope(format!(
-                    " got {}",
+                    "got {}",
                     scope
                 )))
             }
@@ -804,7 +804,7 @@ impl ScopedVariable {
             Value::SyntaxNode(scope) => scope,
             _ => {
                 return Err(ExecutionError::InvalidVariableScope(format!(
-                    " got {}",
+                    "got {}",
                     scope
                 )))
             }
@@ -821,7 +821,7 @@ impl ScopedVariable {
             Value::SyntaxNode(scope) => scope,
             _ => {
                 return Err(ExecutionError::InvalidVariableScope(format!(
-                    " got {}",
+                    "got {}",
                     scope,
                 )))
             }

--- a/src/lazy_execution/store.rs
+++ b/src/lazy_execution/store.rs
@@ -148,7 +148,12 @@ impl LazyScopedVariables {
                 let mut map = HashMap::new();
                 let mut debug_infos = HashMap::new();
                 for (scope, value, debug_info) in pairs.into_iter() {
-                    let node = scope.evaluate_as_syntax_node(exec)?;
+                    let node = scope.evaluate_as_syntax_node(exec).with_context(|| {
+                        format!(
+                            "Evaluating scope of variable _.{} set at {}",
+                            name, debug_info
+                        )
+                    })?;
                     let prev_debug_info = debug_infos.insert(node, debug_info.clone());
                     match map.insert(node, value.clone()) {
                         Some(_) => {

--- a/src/lazy_execution/values.rs
+++ b/src/lazy_execution/values.rs
@@ -138,7 +138,7 @@ impl LazyValue {
         let node = self.evaluate(exec)?;
         match node {
             Value::GraphNode(node) => Ok(node),
-            _ => Err(ExecutionError::ExpectedGraphNode(format!(" got {}", node))),
+            _ => Err(ExecutionError::ExpectedGraphNode(format!("got {}", node))),
         }
     }
 
@@ -149,7 +149,7 @@ impl LazyValue {
         let node = self.evaluate(exec)?;
         match node {
             Value::SyntaxNode(node) => Ok(node),
-            _ => Err(ExecutionError::ExpectedSyntaxNode(format!(" got {}", node))),
+            _ => Err(ExecutionError::ExpectedSyntaxNode(format!("got {}", node))),
         }
     }
 }


### PR DESCRIPTION
The error message when the scope of a scoped variable is not a syntax node are confusing when lazy evaluation is used, because only the use site that triggers the error is reported.
These changes add the TSG location where the scoped variable is defined to the error context.

The messages might be improved even more by not including the use site at all.
After all, it does not really contribute to the error---any use site could have triggered it.
But that is a more invasive change that I'd consider doing in a separate PR.

Fixes #67.
