### PR TITLE
Pass globals as command-line options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ cli = ["clap", "env_logger", "tree-sitter-config", "tree-sitter-loader"]
 
 [dependencies.clap]
 optional = true
-version = "2.32"
+version = "3.2"
 
 [dependencies.env_logger]
 optional = true

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -36,13 +36,13 @@ fn main() -> Result<()> {
         .arg(Arg::with_name("source").index(2).required(true))
         .arg(
             Arg::with_name("quiet")
-                .short("q")
+                .short('q')
                 .long("quiet")
                 .help("Suppress console output"),
         )
         .arg(
             Arg::with_name("lazy")
-                .short("z")
+                .short('z')
                 .long("lazy")
                 .help("Use lazy evaluation (experimental)"),
         )
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
         .arg(Arg::with_name("json").long("json").takes_value(false))
         .arg(
             Arg::with_name("output")
-                .short("o")
+                .short('o')
                 .long("output")
                 .requires("json")
                 .takes_value(true),

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use anyhow::anyhow;
 use anyhow::Context as _;
 use anyhow::Result;
+use clap::builder::ArgAction;
 use clap::App;
 use clap::Arg;
 use tree_sitter::Parser;
@@ -60,6 +61,12 @@ fn main() -> Result<()> {
                 .long("allow-parse-errors")
                 .takes_value(false),
         )
+        .arg(
+            Arg::with_name("global")
+                .long("global")
+                .takes_value(true)
+                .action(ArgAction::Append),
+        )
         .get_matches();
 
     let tsg_path = Path::new(matches.value_of("tsg").unwrap());
@@ -67,6 +74,7 @@ fn main() -> Result<()> {
     let current_dir = std::env::current_dir().unwrap();
     let quiet = matches.is_present("quiet");
     let lazy = matches.is_present("lazy");
+    let globals = matches.get_many::<String>("global").unwrap_or_default();
 
     let config = Config::load()?;
     let mut loader = Loader::new()?;

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -136,8 +136,7 @@ fn main() -> Result<()> {
     }
 
     let mut functions = Functions::stdlib();
-    let globals = Variables::new();
-    let mut config = ExecutionConfig::new(&mut functions, &globals).lazy(lazy);
+    let mut config = ExecutionConfig::new(&mut functions, &globals_).lazy(lazy);
     let graph = file
         .execute(&tree, &source, &mut config)
         .with_context(|| format!("Cannot execute TSG file {}", tsg_path.display()))?;

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -75,6 +75,11 @@ fn main() -> Result<()> {
     let quiet = matches.is_present("quiet");
     let lazy = matches.is_present("lazy");
     let globals = matches.get_many::<String>("global").unwrap_or_default();
+    for kv in globals {
+        let (k, v) = kv
+            .split_once('=')
+            .with_context(|| format!("Expected key-value pair separated by '=', got {}.", kv))?;
+    }
 
     let config = Config::load()?;
     let mut loader = Loader::new()?;

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -17,8 +17,10 @@ use tree_sitter::Parser;
 use tree_sitter_config::Config;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::graph;
 use tree_sitter_graph::parse_error::ParseError;
 use tree_sitter_graph::ExecutionConfig;
+use tree_sitter_graph::Identifier;
 use tree_sitter_graph::Variables;
 use tree_sitter_loader::Loader;
 
@@ -75,12 +77,15 @@ fn main() -> Result<()> {
     let quiet = matches.is_present("quiet");
     let lazy = matches.is_present("lazy");
     let globals = matches.get_many::<String>("global").unwrap_or_default();
-    let mut globals_: Vec<(&str, &str)> = Vec::new();
+    let mut globals_ = Variables::new();
     for kv in globals {
         let kv_ = kv
             .split_once('=')
             .with_context(|| format!("Expected key-value pair separated by '=', got {}.", kv))?;
-        globals_.push(kv_);
+        globals_.add(
+            Identifier::from(kv_.0),
+            graph::Value::String(kv_.1.to_string()),
+        )?;
     }
 
     let config = Config::load()?;

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -75,10 +75,12 @@ fn main() -> Result<()> {
     let quiet = matches.is_present("quiet");
     let lazy = matches.is_present("lazy");
     let globals = matches.get_many::<String>("global").unwrap_or_default();
+    let mut globals_: Vec<(&str, &str)> = Vec::new();
     for kv in globals {
-        let (k, v) = kv
+        let kv_ = kv
             .split_once('=')
             .with_context(|| format!("Expected key-value pair separated by '=', got {}.", kv))?;
+        globals_.push(kv_);
     }
 
     let config = Config::load()?;


### PR DESCRIPTION
- [x] Fixes #76.
- ~~How should types other than `String` be handled?~~ See #86.
- ~~`String::split_once()` seems not to match when the rhs (after the delimiter) is empty. How should we handle empty globals, e.g. empty strings?~~ See #87.