### PR TITLE
Print excerpts from tsg & source files on error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1.0"
 tree-sitter = "0.20"
 serde = "1.0"
 serde_json = "1.0"
+ansi_term = "0.12"
 
 [dependencies.string-interner]
 version = "0.12"

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
     let functions = Functions::stdlib();
     let mut config = ExecutionConfig::new(&functions, &globals_).lazy(lazy);
     let graph = file
-        .execute(&tree, &source, &mut config, &NoCancellation)
+        .execute(&tree, &source, &tsg, &mut config, &NoCancellation)
         .with_context(|| format!("Cannot execute TSG file {}", tsg_path.display()))?;
 
     let json = matches.is_present("json");

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -139,7 +139,15 @@ fn main() -> Result<()> {
     let functions = Functions::stdlib();
     let mut config = ExecutionConfig::new(&functions, &globals_).lazy(lazy);
     let graph = file
-        .execute(&tree, &source, &tsg, &mut config, &NoCancellation)
+        .execute(
+            &tree,
+            source_path,
+            &source,
+            tsg_path,
+            &tsg,
+            &mut config,
+            &NoCancellation,
+        )
         .with_context(|| format!("Cannot execute TSG file {}", tsg_path.display()))?;
 
     let json = matches.is_present("json");

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -393,7 +393,7 @@ impl Stanza {
                         format!(
                             "Executing {} {}",
                             statement,
-                            Excerpt::from_source(source, statement.location())
+                            Excerpt::from_source(tsg_source, statement.location())
                         )
                     })
                 })?;

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -386,7 +386,17 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "{}{}{}\n{}{}{}{}",
+            "{}:{}:{}:\n{}{}{}\n{}{}{}{}",
+            // path and line/col
+            Colour::White
+                .bold()
+                .paint(self.path.to_str().unwrap_or("<unknown file>")),
+            Colour::White
+                .bold()
+                .paint(format!("{}", self.location.row + 1)),
+            Colour::White
+                .bold()
+                .paint(format!("{}", self.location.column + 1)),
             // first line: line number & source
             Colour::Blue.paint(format!("{}", self.location.row + 1)),
             Colour::Blue.paint(" | "),

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -929,9 +929,10 @@ impl ScopedVariable {
             .add(self.name.clone(), value, mutable)
             .map_err(|_| {
                 ExecutionError::DuplicateVariable(format!(
-                    "{}\n{}",
+                    "{}\n{}\n{}",
                     self,
-                    Excerpt::from_source(exec.tsg_source, self.location)
+                    Excerpt::from_source(exec.tsg_source, self.location),
+                    Excerpt::from_source(exec.source, scope.location())
                 ))
             })
     }
@@ -950,9 +951,10 @@ impl ScopedVariable {
         let variables = exec.scoped.get(scope);
         variables.set(self.name.clone(), value).map_err(|_| {
             ExecutionError::DuplicateVariable(format!(
-                "{}\n{}",
+                "{}\n{}\n{}",
                 self,
-                Excerpt::from_source(exec.tsg_source, self.location)
+                Excerpt::from_source(exec.tsg_source, self.location),
+                Excerpt::from_source(exec.source, scope.location())
             ))
         })
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -353,15 +353,14 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let gutter_width = self.gutter_width();
         let column_padding = self.location.column;
+        let empty = "";
         write!(
             f,
-            "{}{}{}\n{:gutter_width$}{}{:column_padding$}{}",
+            "{}{}{}\n{empty:gutter_width$}{}{empty:column_padding$}{}",
             Colour::Blue.paint(format!("{}", self.location.row + 1)),
             Colour::Blue.paint(" | "),
             self.source.unwrap_or("<no source found>"),
-            "",
             Colour::Blue.paint(" | "),
-            "",
             Colour::Green.bold().paint("^")
         )
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -350,7 +350,7 @@ impl Stanza {
             for statement in &self.statements {
                 statement
                     .execute(&mut exec)
-                    .with_context(|| format!("Executing {}", statement))?;
+                    .or_else(|e| Err(e).with_context(|| format!("Executing {}", statement)))?;
             }
         }
         Ok(())

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -403,10 +403,6 @@ impl Stanza {
     }
 }
 
-fn excerpt(source: &str, loc: Location) -> Option<&str> {
-    source.lines().nth(loc.row)
-}
-
 impl Statement {
     fn location(&self) -> Location {
         match self {

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -329,6 +329,7 @@ impl<'a> ScopedVariables<'a> {
     }
 }
 
+/// Excerpts of source from either the target language file or the tsg rules file.
 struct Excerpt<'a> {
     source: Option<&'a str>,
     location: Location,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -363,13 +363,15 @@ impl<'a> ScopedVariables<'a> {
 
 /// Excerpts of source from either the target language file or the tsg rules file.
 struct Excerpt<'a> {
+    path: &'a Path,
     source: Option<&'a str>,
     location: Location,
 }
 
 impl<'a> Excerpt<'a> {
-    fn from_source(source: &'a str, location: Location) -> Excerpt {
+    fn from_source(path: &'a Path, source: &'a str, location: Location) -> Excerpt<'a> {
         Excerpt {
+            path,
             source: source.lines().nth(location.row),
             location: location,
         }
@@ -441,7 +443,7 @@ impl Stanza {
                         format!(
                             "Executing {}\n{}",
                             statement,
-                            Excerpt::from_source(tsg_source, statement.location()) // FIXME: add the statement excerpt to the leaf error instead
+                            Excerpt::from_source(tsg_path, tsg_source, statement.location()) // FIXME: add the statement excerpt to the leaf error instead
                         )
                     })
                 })?;
@@ -976,8 +978,8 @@ impl ScopedVariable {
                 ExecutionError::DuplicateVariable(format!(
                     "{}\n{}\n{}",
                     self,
-                    Excerpt::from_source(exec.tsg_source, self.location),
-                    Excerpt::from_source(exec.source, scope.location())
+                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
+                    Excerpt::from_source(exec.source_path, exec.source, scope.location())
                 ))
             })
     }
@@ -998,8 +1000,8 @@ impl ScopedVariable {
             ExecutionError::DuplicateVariable(format!(
                 "{}\n{}\n{}",
                 self,
-                Excerpt::from_source(exec.tsg_source, self.location),
-                Excerpt::from_source(exec.source, scope.location())
+                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
+                Excerpt::from_source(exec.source_path, exec.source, scope.location())
             ))
         })
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -330,10 +330,7 @@ pub struct CancellationError(pub &'static str);
 
 /// State that is threaded through the execution
 struct ExecutionContext<'a, 'c, 'g, 's, 'tree> {
-    source_path: &'tree Path,
     source: &'tree str,
-    tsg_path: &'a Path,
-    tsg_source: &'a str,
     graph: &'a mut Graph<'tree>,
     config: &'a mut ExecutionConfig<'c, 'g>,
     locals: &'a mut dyn Variables<Value>,
@@ -433,10 +430,7 @@ impl Stanza {
             cancellation_flag.check("processing matches")?;
             locals.clear();
             let mut exec = ExecutionContext {
-                source_path,
                 source,
-                tsg_path,
-                tsg_source,
                 graph,
                 config,
                 locals,
@@ -645,10 +639,7 @@ impl Scan {
 
             let mut arm_locals = VariableMap::nested(exec.locals);
             let mut arm_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut arm_locals,
@@ -704,10 +695,7 @@ impl If {
             if result {
                 let mut arm_locals = VariableMap::nested(exec.locals);
                 let mut arm_exec = ExecutionContext {
-                    source_path: exec.source_path,
                     source: exec.source,
-                    tsg_path: exec.tsg_path,
-                    tsg_source: exec.tsg_source,
                     graph: exec.graph,
                     config: exec.config,
                     locals: &mut arm_locals,
@@ -745,10 +733,7 @@ impl ForIn {
         for value in values {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -819,10 +804,7 @@ impl ListComprehension {
         for value in values {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -860,10 +842,7 @@ impl SetComprehension {
         for value in values {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -1119,10 +1098,7 @@ impl AttributeShorthand {
     {
         let mut shorthand_locals = VariableMap::new();
         let mut shorthand_exec = ExecutionContext {
-            source_path: exec.source_path,
             source: exec.source,
-            tsg_path: exec.tsg_path,
-            tsg_source: exec.tsg_source,
             graph: exec.graph,
             config: exec.config,
             locals: &mut shorthand_locals,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -345,17 +345,6 @@ struct ExecutionContext<'a, 'c, 'g, 's, 'tree> {
     cancellation_flag: &'a dyn CancellationFlag,
 }
 
-impl<'a, 'c, 'g, 's, 'tree> ExecutionContext<'a, 'c, 'g, 's, 'tree> {
-    fn match_location(&self) -> Option<Location> {
-        self.mat
-            .captures
-            .iter()
-            .take(1)
-            .map(|c| Location::from(c.node.range().start_point))
-            .next()
-    }
-}
-
 struct ScopedVariables<'a> {
     scopes: HashMap<SyntaxNodeRef, VariableMap<'a, Value>>,
 }
@@ -984,11 +973,10 @@ impl ScopedVariable {
             Ok(value)
         } else {
             Err(ExecutionError::UndefinedVariable(format!(
-                "{} on node {}\n{}\n{}",
+                "{} on node {}\n{}",
                 self,
                 scope,
-                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
-                Excerpt::from_source(exec.source_path, exec.source, scope.location())
+                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
             )))
         }
     }
@@ -1014,10 +1002,9 @@ impl ScopedVariable {
             .add(self.name.clone(), value, mutable)
             .map_err(|_| {
                 ExecutionError::DuplicateVariable(format!(
-                    "{}\n{}\n{}",
+                    "{}\n{}",
                     self,
-                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
-                    Excerpt::from_source(exec.source_path, exec.source, scope.location())
+                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
                 ))
             })
     }
@@ -1036,10 +1023,9 @@ impl ScopedVariable {
         let variables = exec.scoped.get(scope);
         variables.set(self.name.clone(), value).map_err(|_| {
             ExecutionError::DuplicateVariable(format!(
-                "{}\n{}\n{}",
+                "{}\n{}",
                 self,
-                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
-                Excerpt::from_source(exec.source_path, exec.source, scope.location())
+                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
             ))
         })
     }
@@ -1084,15 +1070,9 @@ impl UnscopedVariable {
                 ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
             } else {
                 ExecutionError::UndefinedVariable(format!(
-                    "{}\n{}\n{}",
+                    "{}\n{}",
                     self,
-                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
-                    Excerpt::from_source(
-                        exec.source_path,
-                        exec.source,
-                        exec.match_location()
-                            .unwrap_or(Location { row: 0, column: 0 })
-                    )
+                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
                 ))
             }
         })

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -453,7 +453,7 @@ impl Stanza {
                         format!(
                             "Executing {}\n{}\n{}",
                             statement,
-                            Excerpt::from_source(tsg_path, tsg_source, statement.location()), // FIXME: add the statement excerpt to the leaf error instead
+                            Excerpt::from_source(tsg_path, tsg_source, statement.location()),
                             Excerpt::from_source(
                                 source_path,
                                 source,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -984,11 +984,8 @@ impl ScopedVariable {
             Ok(value)
         } else {
             Err(ExecutionError::UndefinedVariable(format!(
-                "{} on node {}\n{}\n{}",
-                self,
-                scope,
-                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
-                Excerpt::from_source(exec.source_path, exec.source, scope.location())
+                "{} on node {}",
+                self, scope
             )))
         }
     }
@@ -1083,17 +1080,7 @@ impl UnscopedVariable {
             if exec.locals.get(&self.name).is_some() {
                 ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
             } else {
-                ExecutionError::UndefinedVariable(format!(
-                    "{}\n{}\n{}",
-                    self,
-                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
-                    Excerpt::from_source(
-                        exec.source_path,
-                        exec.source,
-                        exec.match_location()
-                            .unwrap_or(Location { row: 0, column: 0 })
-                    )
-                ))
+                ExecutionError::UndefinedVariable(format!("{}", self))
             }
         })
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -351,16 +351,15 @@ impl<'a> Excerpt<'a> {
 
 impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let gutter_width = self.gutter_width();
-        let column_padding = self.location.column;
-        let empty = "";
         write!(
             f,
-            "{}{}{}\n{empty:gutter_width$}{}{empty:column_padding$}{}",
+            "{}{}{}\n{}{}{}{}",
             Colour::Blue.paint(format!("{}", self.location.row + 1)),
             Colour::Blue.paint(" | "),
             self.source.unwrap_or("<no source found>"),
+            " ".repeat(self.gutter_width()),
             Colour::Blue.paint(" | "),
+            " ".repeat(self.location.column),
             Colour::Green.bold().paint("^")
         )
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -973,10 +973,8 @@ impl ScopedVariable {
             Ok(value)
         } else {
             Err(ExecutionError::UndefinedVariable(format!(
-                "{} on node {}\n{}",
-                self,
-                scope,
-                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
+                "{} on node {}",
+                self, scope
             )))
         }
     }
@@ -1000,13 +998,7 @@ impl ScopedVariable {
         let variables = exec.scoped.get(scope);
         variables
             .add(self.name.clone(), value, mutable)
-            .map_err(|_| {
-                ExecutionError::DuplicateVariable(format!(
-                    "{}\n{}",
-                    self,
-                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
-                ))
-            })
+            .map_err(|_| ExecutionError::DuplicateVariable(format!("{}", self)))
     }
 
     fn set(&self, exec: &mut ExecutionContext, value: Value) -> Result<(), ExecutionError> {
@@ -1021,13 +1013,9 @@ impl ScopedVariable {
             }
         };
         let variables = exec.scoped.get(scope);
-        variables.set(self.name.clone(), value).map_err(|_| {
-            ExecutionError::DuplicateVariable(format!(
-                "{}\n{}",
-                self,
-                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
-            ))
-        })
+        variables
+            .set(self.name.clone(), value)
+            .map_err(|_| ExecutionError::DuplicateVariable(format!("{}", self)))
     }
 }
 
@@ -1069,11 +1057,7 @@ impl UnscopedVariable {
             if exec.locals.get(&self.name).is_some() {
                 ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
             } else {
-                ExecutionError::UndefinedVariable(format!(
-                    "{}\n{}",
-                    self,
-                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location)
-                ))
+                ExecutionError::UndefinedVariable(format!("{}", self))
             }
         })
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -457,8 +457,9 @@ impl Stanza {
                             .unwrap()
                             .node;
                         format!(
-                            "Executing statement {}\n{}\nfor ({}) node at source position\n{}",
+                            "While executing statement {}\nin stanza\n{}\n{}\nmatching ({}) node\n{}",
                             statement,
+                            Excerpt::from_source(tsg_path, tsg_source, self.location),
                             Excerpt::from_source(tsg_path, tsg_source, statement.location()),
                             node.kind(),
                             Excerpt::from_source(

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -228,7 +228,7 @@ pub enum ExecutionError {
     DuplicateAttribute(String),
     #[error("Duplicate edge {0}")]
     DuplicateEdge(String),
-    #[error("Duplicate variable {0}")]
+    #[error("Duplicate variable {0} at {1}")]
     DuplicateVariable(String, Location),
     #[error("Expected a graph node reference {0}")]
     ExpectedGraphNode(String),

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -348,7 +348,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         write!(
             f,
             "{} | {}",
-            self.location,
+            self.location.row,
             self.source.unwrap_or("<no source found>")
         )
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use ansi_term::Colour;
 use anyhow::Context as ErrorContext;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -354,11 +355,12 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         let column_padding = self.location.column;
         write!(
             f,
-            "{} | {}\n{:gutter_width$} | {:column_padding$}^",
+            "{} | {}\n{:gutter_width$} | {:column_padding$}{}",
             self.location.row + 1,
             self.source.unwrap_or("<no source found>"),
             "",
-            ""
+            "",
+            Colour::Green.bold().paint("^")
         )
     }
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -392,7 +392,7 @@ impl Stanza {
                 statement.execute(&mut exec).or_else(|e| {
                     Err(e).with_context(|| {
                         format!(
-                            "Executing {} {}",
+                            "Executing {}\n{}",
                             statement,
                             Excerpt::from_source(tsg_source, statement.location())
                         )

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -345,6 +345,17 @@ struct ExecutionContext<'a, 'c, 'g, 's, 'tree> {
     cancellation_flag: &'a dyn CancellationFlag,
 }
 
+impl<'a, 'c, 'g, 's, 'tree> ExecutionContext<'a, 'c, 'g, 's, 'tree> {
+    fn match_location(&self, tree: Tree) -> Option<Location> {
+        self.mat
+            .captures
+            .iter()
+            .take(1)
+            .map(|c| Location::from(c.node.range().start_point))
+            .next()
+    }
+}
+
 struct ScopedVariables<'a> {
     scopes: HashMap<SyntaxNodeRef, VariableMap<'a, Value>>,
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -329,6 +329,11 @@ impl<'a> ScopedVariables<'a> {
     }
 }
 
+struct Excerpt<'a> {
+    source: &'a str,
+    location: Location,
+}
+
 impl Stanza {
     fn execute<'a, 'g, 'l, 's, 'tree>(
         &self,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -457,9 +457,10 @@ impl Stanza {
                             .unwrap()
                             .node;
                         format!(
-                            "Executing statement {}\n{}\nfor source position\n{}",
+                            "Executing statement {}\n{}\nfor ({}) node at source position\n{}",
                             statement,
                             Excerpt::from_source(tsg_path, tsg_source, statement.location()),
+                            node.kind(),
                             Excerpt::from_source(
                                 source_path,
                                 source,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -346,7 +346,7 @@ struct ExecutionContext<'a, 'c, 'g, 's, 'tree> {
 }
 
 impl<'a, 'c, 'g, 's, 'tree> ExecutionContext<'a, 'c, 'g, 's, 'tree> {
-    fn match_location(&self, tree: Tree) -> Option<Location> {
+    fn match_location(&self) -> Option<Location> {
         self.mat
             .captures
             .iter()

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -355,10 +355,12 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         let column_padding = self.location.column;
         write!(
             f,
-            "{} | {}\n{:gutter_width$} | {:column_padding$}{}",
-            self.location.row + 1,
+            "{}{}{}\n{:gutter_width$}{}{:column_padding$}{}",
+            Colour::Blue.paint(format!("{}", self.location.row + 1)),
+            Colour::Blue.paint(" | "),
             self.source.unwrap_or("<no source found>"),
             "",
+            Colour::Blue.paint(" | "),
             "",
             Colour::Green.bold().paint("^")
         )

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -984,8 +984,11 @@ impl ScopedVariable {
             Ok(value)
         } else {
             Err(ExecutionError::UndefinedVariable(format!(
-                "{} on node {}",
-                self, scope
+                "{} on node {}\n{}\n{}",
+                self,
+                scope,
+                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
+                Excerpt::from_source(exec.source_path, exec.source, scope.location())
             )))
         }
     }
@@ -1080,7 +1083,17 @@ impl UnscopedVariable {
             if exec.locals.get(&self.name).is_some() {
                 ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
             } else {
-                ExecutionError::UndefinedVariable(format!("{}", self))
+                ExecutionError::UndefinedVariable(format!(
+                    "{}\n{}\n{}",
+                    self,
+                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
+                    Excerpt::from_source(
+                        exec.source_path,
+                        exec.source,
+                        exec.match_location()
+                            .unwrap_or(Location { row: 0, column: 0 })
+                    )
+                ))
             }
         })
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -342,6 +342,10 @@ impl<'a> Excerpt<'a> {
             location: location,
         }
     }
+
+    fn gutter_width(&self) -> usize {
+        ((self.location.row + 1) as f64).log10() as usize + 1
+    }
 }
 
 impl<'a> std::fmt::Display for Excerpt<'a> {

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -970,8 +970,11 @@ impl ScopedVariable {
             Ok(value)
         } else {
             Err(ExecutionError::UndefinedVariable(format!(
-                "{} on node {}",
-                self, scope
+                "{} on node {}\n{}\n{}",
+                self,
+                scope,
+                Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
+                Excerpt::from_source(exec.source_path, exec.source, scope.location())
             )))
         }
     }
@@ -1066,7 +1069,17 @@ impl UnscopedVariable {
             if exec.locals.get(&self.name).is_some() {
                 ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
             } else {
-                ExecutionError::UndefinedVariable(format!("{}", self))
+                ExecutionError::UndefinedVariable(format!(
+                    "{}\n{}\n{}",
+                    self,
+                    Excerpt::from_source(exec.tsg_path, exec.tsg_source, self.location),
+                    Excerpt::from_source(
+                        exec.source_path,
+                        exec.source,
+                        exec.match_location()
+                            .unwrap_or(Location { row: 0, column: 0 })
+                    )
+                ))
             }
         })
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -394,7 +394,7 @@ impl Stanza {
                         format!(
                             "Executing {}\n{}",
                             statement,
-                            Excerpt::from_source(tsg_source, statement.location())
+                            Excerpt::from_source(tsg_source, statement.location()) // FIXME: add the statement excerpt to the leaf error instead
                         )
                     })
                 })?;

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -477,7 +477,7 @@ impl Stanza {
 }
 
 impl Statement {
-    fn location(&self) -> Location {
+    pub fn location(&self) -> Location {
         match self {
             Statement::DeclareImmutable(s) => s.location,
             Statement::DeclareMutable(s) => s.location,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -457,10 +457,10 @@ impl Stanza {
                             .unwrap()
                             .node;
                         format!(
-                            "While executing statement {}\nin stanza\n{}\n{}\nmatching ({}) node\n{}",
+                            "While executing statement {}\n{}\nin stanza\n{}\nmatching ({}) node\n{}",
                             statement,
-                            Excerpt::from_source(tsg_path, tsg_source, self.location),
                             Excerpt::from_source(tsg_path, tsg_source, statement.location()),
+                            Excerpt::from_source(tsg_path, tsg_source, self.location),
                             node.kind(),
                             Excerpt::from_source(
                                 source_path,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -362,14 +362,14 @@ impl<'a> ScopedVariables<'a> {
 }
 
 /// Excerpts of source from either the target language file or the tsg rules file.
-struct Excerpt<'a> {
+pub struct Excerpt<'a> {
     path: &'a Path,
     source: Option<&'a str>,
     location: Location,
 }
 
 impl<'a> Excerpt<'a> {
-    fn from_source(path: &'a Path, source: &'a str, location: Location) -> Excerpt<'a> {
+    pub fn from_source(path: &'a Path, source: &'a str, location: Location) -> Excerpt<'a> {
         Excerpt {
             path,
             source: source.lines().nth(location.row),

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -95,7 +95,7 @@ impl File {
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), ExecutionError> {
         if config.lazy {
-            self.execute_lazy_into(graph, tree, source, config, cancellation_flag)
+            self.execute_lazy_into(graph, tree, source, tsg_source, config, cancellation_flag)
         } else {
             self.execute_strict_into(graph, tree, source, tsg_source, config, cancellation_flag)
         }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -350,11 +350,15 @@ impl<'a> Excerpt<'a> {
 
 impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let gutter_width = self.gutter_width();
+        let column_padding = self.location.column;
         write!(
             f,
-            "{} | {}",
+            "{} | {}\n{:gutter_width$} | {:column_padding$}^",
             self.location.row + 1,
-            self.source.unwrap_or("<no source found>")
+            self.source.unwrap_or("<no source found>"),
+            "",
+            ""
         )
     }
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -451,7 +451,7 @@ impl Stanza {
                 statement.execute(&mut exec).or_else(|e| {
                     Err(e).with_context(|| {
                         format!(
-                            "Executing {}\n{}\n{}",
+                            "Executing statement {}\n{}\nfor source position\n{}",
                             statement,
                             Excerpt::from_source(tsg_path, tsg_source, statement.location()),
                             Excerpt::from_source(

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -923,7 +923,16 @@ impl ScopedVariable {
         let variables = exec.scoped.get(scope);
         variables
             .add(self.name.clone(), value, mutable)
-            .map_err(|_| ExecutionError::DuplicateVariable(format!("{}", self), self.location))
+            .map_err(|_| {
+                ExecutionError::DuplicateVariable(
+                    format!(
+                        "{}\n{}",
+                        self,
+                        Excerpt::from_source(exec.tsg_source, self.location)
+                    ),
+                    self.location,
+                )
+            })
     }
 
     fn set(&self, exec: &mut ExecutionContext, value: Value) -> Result<(), ExecutionError> {
@@ -938,9 +947,16 @@ impl ScopedVariable {
             }
         };
         let variables = exec.scoped.get(scope);
-        variables
-            .set(self.name.clone(), value)
-            .map_err(|_| ExecutionError::DuplicateVariable(format!("{}", self), self.location))
+        variables.set(self.name.clone(), value).map_err(|_| {
+            ExecutionError::DuplicateVariable(
+                format!(
+                    "{}\n{}",
+                    self,
+                    Excerpt::from_source(exec.tsg_source, self.location)
+                ),
+                self.location,
+            )
+        })
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -893,7 +893,7 @@ impl ScopedVariable {
         let variables = exec.scoped.get(scope);
         variables
             .add(self.name.clone(), value, mutable)
-            .map_err(|_| ExecutionError::DuplicateVariable(format!(" {}", self), self.location))
+            .map_err(|_| ExecutionError::DuplicateVariable(format!("{}", self), self.location))
     }
 
     fn set(&self, exec: &mut ExecutionContext, value: Value) -> Result<(), ExecutionError> {
@@ -910,7 +910,7 @@ impl ScopedVariable {
         let variables = exec.scoped.get(scope);
         variables
             .set(self.name.clone(), value)
-            .map_err(|_| ExecutionError::DuplicateVariable(format!(" {}", self), self.location))
+            .map_err(|_| ExecutionError::DuplicateVariable(format!("{}", self), self.location))
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -334,6 +334,15 @@ struct Excerpt<'a> {
     location: Location,
 }
 
+impl<'a> Excerpt<'a> {
+    fn from_source(source: &'a str, location: Location) -> Excerpt {
+        Excerpt {
+            source: source.lines().nth(location.row).unwrap(),
+            location: location,
+        }
+    }
+}
+
 impl Stanza {
     fn execute<'a, 'g, 'l, 's, 'tree>(
         &self,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -450,6 +450,12 @@ impl Stanza {
             for statement in &self.statements {
                 statement.execute(&mut exec).or_else(|e| {
                     Err(e).with_context(|| {
+                        let node = mat
+                            .captures
+                            .iter()
+                            .find(|c| c.index as usize == self.full_match_file_capture_index)
+                            .unwrap()
+                            .node;
                         format!(
                             "Executing statement {}\n{}\nfor source position\n{}",
                             statement,
@@ -457,16 +463,7 @@ impl Stanza {
                             Excerpt::from_source(
                                 source_path,
                                 source,
-                                Location::from(
-                                    mat.captures
-                                        .iter()
-                                        .find(|c| c.index as usize
-                                            == self.full_match_file_capture_index)
-                                        .unwrap()
-                                        .node
-                                        .range()
-                                        .start_point
-                                )
+                                Location::from(node.range().start_point)
                             )
                         )
                     })

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -348,7 +348,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         write!(
             f,
             "{} | {}",
-            self.location.row,
+            self.location.row + 1,
             self.source.unwrap_or("<no source found>")
         )
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -462,9 +462,23 @@ impl Stanza {
                 statement.execute(&mut exec).or_else(|e| {
                     Err(e).with_context(|| {
                         format!(
-                            "Executing {}\n{}",
+                            "Executing {}\n{}\n{}",
                             statement,
-                            Excerpt::from_source(tsg_path, tsg_source, statement.location()) // FIXME: add the statement excerpt to the leaf error instead
+                            Excerpt::from_source(tsg_path, tsg_source, statement.location()), // FIXME: add the statement excerpt to the leaf error instead
+                            Excerpt::from_source(
+                                source_path,
+                                source,
+                                Location::from(
+                                    mat.captures
+                                        .iter()
+                                        .find(|c| c.index as usize
+                                            == self.full_match_file_capture_index)
+                                        .unwrap()
+                                        .node
+                                        .range()
+                                        .start_point
+                                )
+                            )
                         )
                     })
                 })?;

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -388,7 +388,7 @@ impl Stanza {
                         format!(
                             "Executing {} {}",
                             statement,
-                            excerpt(source, statement.location()).unwrap_or_default()
+                            Excerpt::from_source(source, statement.location())
                         )
                     })
                 })?;

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -343,6 +343,12 @@ impl<'a> Excerpt<'a> {
     }
 }
 
+impl<'a> std::fmt::Display for Excerpt<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} | {}", self.location, self.source)
+    }
+}
+
 impl Stanza {
     fn execute<'a, 'g, 'l, 's, 'tree>(
         &self,

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -354,9 +354,11 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         write!(
             f,
             "{}{}{}\n{}{}{}{}",
+            // first line: line number & source
             Colour::Blue.paint(format!("{}", self.location.row + 1)),
             Colour::Blue.paint(" | "),
             self.source.unwrap_or("<no source found>"),
+            // second line: caret
             " ".repeat(self.gutter_width()),
             Colour::Blue.paint(" | "),
             " ".repeat(self.location.column),

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -330,14 +330,14 @@ impl<'a> ScopedVariables<'a> {
 }
 
 struct Excerpt<'a> {
-    source: &'a str,
+    source: Option<&'a str>,
     location: Location,
 }
 
 impl<'a> Excerpt<'a> {
     fn from_source(source: &'a str, location: Location) -> Excerpt {
         Excerpt {
-            source: source.lines().nth(location.row).unwrap(),
+            source: source.lines().nth(location.row),
             location: location,
         }
     }
@@ -345,7 +345,12 @@ impl<'a> Excerpt<'a> {
 
 impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{} | {}", self.location, self.source)
+        write!(
+            f,
+            "{} | {}",
+            self.location,
+            self.source.unwrap_or("<no source found>")
+        )
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -33,6 +33,7 @@ use tree_sitter::Node;
 
 use crate::execution::ExecutionError;
 use crate::Identifier;
+use crate::Location;
 
 /// A graph produced by executing a graph DSL file.  Graphs include a lifetime parameter to ensure
 /// that they don't outlive the tree-sitter syntax tree that they are generated from.
@@ -600,6 +601,15 @@ pub struct SyntaxNodeRef {
     index: SyntaxNodeID,
     kind: &'static str,
     position: tree_sitter::Point,
+}
+
+impl SyntaxNodeRef {
+    pub fn location(&self) -> Location {
+        Location {
+            row: self.position.row,
+            column: self.position.column,
+        }
+    }
 }
 
 impl From<SyntaxNodeRef> for Value {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -603,12 +603,18 @@ pub struct SyntaxNodeRef {
     position: tree_sitter::Point,
 }
 
+impl From<tree_sitter::Point> for Location {
+    fn from(point: tree_sitter::Point) -> Location {
+        Location {
+            row: point.row,
+            column: point.column,
+        }
+    }
+}
+
 impl SyntaxNodeRef {
     pub fn location(&self) -> Location {
-        Location {
-            row: self.position.row,
-            column: self.position.column,
-        }
+        Location::from(self.position)
     }
 }
 

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -109,10 +109,7 @@ impl ast::File {
 
 /// Context for execution, which executes stanzas to build the lazy graph
 struct ExecutionContext<'a, 'c, 'g, 'tree> {
-    source_path: &'tree Path,
     source: &'tree str,
-    tsg_path: &'a Path,
-    tsg_source: &'a str,
     graph: &'a mut Graph<'tree>,
     config: &'a mut ExecutionConfig<'c, 'g>,
     locals: &'a mut dyn Variables<LazyValue>,
@@ -168,10 +165,7 @@ impl ast::Stanza {
         let current_regex_captures = vec![];
         locals.clear();
         let mut exec = ExecutionContext {
-            source_path,
             source,
-            tsg_path,
-            tsg_source,
             graph,
             config,
             locals,
@@ -351,10 +345,7 @@ impl ast::Scan {
 
             let mut arm_locals = VariableMap::nested(exec.locals);
             let mut arm_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut arm_locals,
@@ -418,10 +409,7 @@ impl ast::If {
             if result {
                 let mut arm_locals = VariableMap::nested(exec.locals);
                 let mut arm_exec = ExecutionContext {
-                    source_path: exec.source_path,
                     source: exec.source,
-                    tsg_path: exec.tsg_path,
-                    tsg_source: exec.tsg_source,
                     graph: exec.graph,
                     config: exec.config,
                     locals: &mut arm_locals,
@@ -467,10 +455,7 @@ impl ast::ForIn {
         for value in values {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -564,10 +549,7 @@ impl ast::ListComprehension {
                 .check("executing list comprehension values")?;
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -610,10 +592,7 @@ impl ast::SetComprehension {
                 .check("executing set comprehension values")?;
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
-                source_path: exec.source_path,
                 source: exec.source,
-                tsg_path: exec.tsg_path,
-                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -827,10 +806,7 @@ impl ast::AttributeShorthand {
     {
         let mut shorthand_locals = VariableMap::new();
         let mut shorthand_exec = ExecutionContext {
-            source_path: exec.source_path,
             source: exec.source,
-            tsg_path: exec.tsg_path,
-            tsg_source: exec.tsg_source,
             graph: exec.graph,
             config: exec.config,
             locals: &mut shorthand_locals,

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -695,7 +695,7 @@ impl ast::UnscopedVariable {
         } else {
             exec.locals.get(&self.name).map(|value| value.clone())
         }
-        .ok_or_else(|| ExecutionError::UndefinedVariable(format!("{}", self)))
+        .ok_or_else(|| ExecutionError::UndefinedVariable(format!("{}", self), self.location))
     }
 }
 
@@ -736,7 +736,7 @@ impl ast::UnscopedVariable {
                 if exec.locals.get(&self.name).is_some() {
                     ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
                 } else {
-                    ExecutionError::UndefinedVariable(format!("{}", self))
+                    ExecutionError::UndefinedVariable(format!("{}", self), self.location)
                 }
             })
     }

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -41,11 +41,12 @@ impl ast::File {
     /// text that it was parsed from (`source`).  You also provide the set of functions and global
     /// variables that are available during execution. This variant is useful when you need to
     /// “pre-seed” the graph with some predefined nodes and/or edges before executing the DSL file.
-    pub(crate) fn execute_lazy_into<'tree>(
+    pub(crate) fn execute_lazy_into<'a, 'tree>(
         &self,
         graph: &mut Graph<'tree>,
         tree: &'tree Tree,
         source: &'tree str,
+        tsg_source: &'a str,
         config: &mut ExecutionConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), ExecutionError> {
@@ -65,6 +66,7 @@ impl ast::File {
             let stanza = &self.stanzas[mat.pattern_index];
             stanza.execute_lazy(
                 source,
+                tsg_source,
                 &mat,
                 graph,
                 config,
@@ -101,6 +103,7 @@ impl ast::File {
 /// Context for execution, which executes stanzas to build the lazy graph
 struct ExecutionContext<'a, 'c, 'g, 'tree> {
     source: &'tree str,
+    tsg_source: &'a str,
     graph: &'a mut Graph<'tree>,
     config: &'a mut ExecutionConfig<'c, 'g>,
     locals: &'a mut dyn Variables<LazyValue>,
@@ -138,6 +141,7 @@ impl ast::Stanza {
     fn execute_lazy<'a, 'l, 'g, 'q, 'tree>(
         &self,
         source: &'tree str,
+        tsg_source: &'a str,
         mat: &QueryMatch<'_, 'tree>,
         graph: &mut Graph<'tree>,
         config: &mut ExecutionConfig,
@@ -154,6 +158,7 @@ impl ast::Stanza {
         locals.clear();
         let mut exec = ExecutionContext {
             source,
+            tsg_source,
             graph,
             config,
             locals,
@@ -315,6 +320,7 @@ impl ast::Scan {
             let mut arm_locals = VariableMap::nested(exec.locals);
             let mut arm_exec = ExecutionContext {
                 source: exec.source,
+                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut arm_locals,
@@ -379,6 +385,7 @@ impl ast::If {
                 let mut arm_locals = VariableMap::nested(exec.locals);
                 let mut arm_exec = ExecutionContext {
                     source: exec.source,
+                    tsg_source: exec.tsg_source,
                     graph: exec.graph,
                     config: exec.config,
                     locals: &mut arm_locals,
@@ -425,6 +432,7 @@ impl ast::ForIn {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
                 source: exec.source,
+                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -519,6 +527,7 @@ impl ast::ListComprehension {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
                 source: exec.source,
+                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -562,6 +571,7 @@ impl ast::SetComprehension {
             loop_locals.clear();
             let mut loop_exec = ExecutionContext {
                 source: exec.source,
+                tsg_source: exec.tsg_source,
                 graph: exec.graph,
                 config: exec.config,
                 locals: &mut loop_locals,
@@ -776,6 +786,7 @@ impl ast::AttributeShorthand {
         let mut shorthand_locals = VariableMap::new();
         let mut shorthand_exec = ExecutionContext {
             source: exec.source,
+            tsg_source: exec.tsg_source,
             graph: exec.graph,
             config: exec.config,
             locals: &mut shorthand_locals,

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -705,7 +705,7 @@ impl ast::UnscopedVariable {
         } else {
             exec.locals.get(&self.name).map(|value| value.clone())
         }
-        .ok_or_else(|| ExecutionError::UndefinedVariable(format!("{}", self), self.location))
+        .ok_or_else(|| ExecutionError::UndefinedVariable(format!("{}", self)))
     }
 }
 
@@ -717,17 +717,15 @@ impl ast::UnscopedVariable {
         mutable: bool,
     ) -> Result<(), ExecutionError> {
         if exec.config.globals.get(&self.name).is_some() {
-            return Err(ExecutionError::DuplicateVariable(
-                format!(" global {}", self),
-                self.location,
-            ));
+            return Err(ExecutionError::DuplicateVariable(format!(
+                " global {}",
+                self
+            )));
         }
         let value = exec.store.add(value, self.location.into());
         exec.locals
             .add(self.name.clone(), value.into(), mutable)
-            .map_err(|_| {
-                ExecutionError::DuplicateVariable(format!(" local {}", self), self.location)
-            })
+            .map_err(|_| ExecutionError::DuplicateVariable(format!(" local {}", self)))
     }
 
     fn set_lazy(
@@ -748,7 +746,7 @@ impl ast::UnscopedVariable {
                 if exec.locals.get(&self.name).is_some() {
                     ExecutionError::CannotAssignImmutableVariable(format!("{}", self))
                 } else {
-                    ExecutionError::UndefinedVariable(format!("{}", self), self.location)
+                    ExecutionError::UndefinedVariable(format!("{}", self))
                 }
             })
     }

--- a/src/lazy_execution.rs
+++ b/src/lazy_execution.rs
@@ -717,15 +717,17 @@ impl ast::UnscopedVariable {
         mutable: bool,
     ) -> Result<(), ExecutionError> {
         if exec.config.globals.get(&self.name).is_some() {
-            return Err(ExecutionError::DuplicateVariable(format!(
-                " global {}",
-                self
-            )));
+            return Err(ExecutionError::DuplicateVariable(
+                format!(" global {}", self),
+                self.location,
+            ));
         }
         let value = exec.store.add(value, self.location.into());
         exec.locals
             .add(self.name.clone(), value.into(), mutable)
-            .map_err(|_| ExecutionError::DuplicateVariable(format!(" local {}", self)))
+            .map_err(|_| {
+                ExecutionError::DuplicateVariable(format!(" local {}", self), self.location)
+            })
     }
 
     fn set_lazy(

--- a/src/lazy_execution/store.rs
+++ b/src/lazy_execution/store.rs
@@ -157,13 +157,16 @@ impl LazyScopedVariables {
                     let prev_debug_info = debug_infos.insert(node, debug_info.clone());
                     match map.insert(node, value.clone()) {
                         Some(_) => {
-                            return Err(ExecutionError::DuplicateVariable(format!(
-                                "{}.{} set at {} and {}",
-                                node,
-                                name,
-                                prev_debug_info.unwrap(),
-                                debug_info,
-                            )));
+                            return Err(ExecutionError::DuplicateVariable(
+                                format!(
+                                    "{}.{} set at {} and {}",
+                                    node,
+                                    name,
+                                    prev_debug_info.unwrap(),
+                                    debug_info,
+                                ),
+                                node.location(),
+                            ));
                         }
                         _ => {}
                     };

--- a/src/lazy_execution/store.rs
+++ b/src/lazy_execution/store.rs
@@ -157,16 +157,13 @@ impl LazyScopedVariables {
                     let prev_debug_info = debug_infos.insert(node, debug_info.clone());
                     match map.insert(node, value.clone()) {
                         Some(_) => {
-                            return Err(ExecutionError::DuplicateVariable(
-                                format!(
-                                    "{}.{} set at {} and {}",
-                                    node,
-                                    name,
-                                    prev_debug_info.unwrap(),
-                                    debug_info,
-                                ),
-                                node.location(),
-                            ));
+                            return Err(ExecutionError::DuplicateVariable(format!(
+                                "{}.{} set at {} and {}",
+                                node,
+                                name,
+                                prev_debug_info.unwrap(),
+                                debug_info,
+                            )));
                         }
                         _ => {}
                     };

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -40,7 +40,7 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     let graph = file.execute(
         &tree,
         python_source,
-        &dsl_source,
+        dsl_source,
         &mut config,
         &NoCancellation,
     )?;

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 use indoc::indoc;
+use std::path::Path;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
@@ -39,7 +40,9 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     let mut config = ExecutionConfig::new(&functions, &globals);
     let graph = file.execute(
         &tree,
+        &Path::new("test.py"),
         python_source,
+        &Path::new("test.tsg"),
         dsl_source,
         &mut config,
         &NoCancellation,

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -37,7 +37,13 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         .add(Identifier::from("filename"), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
     let mut config = ExecutionConfig::new(&functions, &globals);
-    let graph = file.execute(&tree, python_source, &mut config, &NoCancellation)?;
+    let graph = file.execute(
+        &tree,
+        python_source,
+        &dsl_source,
+        &mut config,
+        &NoCancellation,
+    )?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 use indoc::indoc;
+use std::path::Path;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
@@ -38,7 +39,9 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
     let mut config = ExecutionConfig::new(&functions, &globals).lazy(true);
     let graph = file.execute(
         &tree,
+        &Path::new("test.py"),
         python_source,
+        &Path::new("test.tsg"),
         &dsl_source,
         &mut config,
         &NoCancellation,

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -36,7 +36,13 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         .add("filename".into(), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
     let mut config = ExecutionConfig::new(&functions, &globals).lazy(true);
-    let graph = file.execute(&tree, python_source, &mut config, &NoCancellation)?;
+    let graph = file.execute(
+        &tree,
+        python_source,
+        &dsl_source,
+        &mut config,
+        &NoCancellation,
+    )?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }


### PR DESCRIPTION
- [x] Fixes #63.
- [x] Fixes #83.
- [x] Fixes #84.
- [x] Fixes #90.
- [x] Apply to lazy evaluation.

<img width="490" alt="screenshot of terminal session showing new error messages with context from both tsg and target language files" src="https://user-images.githubusercontent.com/59671/184410447-9e47548c-5cb4-487e-8d1a-f7c92ee9b0be.png">
