### PR TITLE
Add cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- Cancellation of `ast::File` execution is now supported by passing an implementation of the
-  `CancellationFlag` trait. Convenience implementations are provided as associated methods on
-  `CancellationFlags`.
+- Cancellation of `ast::File` execution is now supported by passing an implementation of the `CancellationFlag` trait.
+  The `NoCancellation` type provides a noop implementation.
 
 #### Fixed
 
@@ -22,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - Functions are not passed as mutable anymore, so that they can safely used concurrently and reused between executions.
-- `ast::File::execute` requires an extra `CancellationFlag` parameter. Use
-  `&CancellationFlags::none()` if no cancellation is required.
+- `ast::File::execute` requires an extra `CancellationFlag` parameter. Use `&NoCancellation` if no cancellation is required.
 
 ## 0.5.1 -- 2022-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Library
 
+#### Added
+
+- Cancellation of `ast::File` execution is now supported by passing an implementation of the
+  `CancellationFlag` trait. Convenience implementations are provided as associated methods on
+  `CancellationFlags`.
+
 #### Fixed
 
 - Fixed bug in `Identifier` so `ast::File` instances can be safely shared between threads.
@@ -16,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - Functions are not passed as mutable anymore, so that they can safely used concurrently and reused between executions.
+- `ast::File::execute` requires an extra `CancellationFlag` parameter. Use
+  `&CancellationFlags::none()` if no cancellation is required.
 
 ## 0.5.1 -- 2022-05-11
 

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -19,9 +19,9 @@ use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::graph;
 use tree_sitter_graph::parse_error::ParseError;
+use tree_sitter_graph::CancellationFlags;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Identifier;
-use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 use tree_sitter_loader::Loader;
 
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
     let functions = Functions::stdlib();
     let mut config = ExecutionConfig::new(&functions, &globals_).lazy(lazy);
     let graph = file
-        .execute(&tree, &source, &mut config, &NoCancellation::default())
+        .execute(&tree, &source, &mut config, &CancellationFlags::none())
         .with_context(|| format!("Cannot execute TSG file {}", tsg_path.display()))?;
 
     let json = matches.is_present("json");

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -19,9 +19,9 @@ use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::graph;
 use tree_sitter_graph::parse_error::ParseError;
-use tree_sitter_graph::CancellationFlags;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Identifier;
+use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 use tree_sitter_loader::Loader;
 
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
     let functions = Functions::stdlib();
     let mut config = ExecutionConfig::new(&functions, &globals_).lazy(lazy);
     let graph = file
-        .execute(&tree, &source, &mut config, &CancellationFlags::none())
+        .execute(&tree, &source, &mut config, &NoCancellation)
         .with_context(|| format!("Cannot execute TSG file {}", tsg_path.display()))?;
 
     let json = matches.is_present("json");

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -21,6 +21,7 @@ use tree_sitter_graph::graph;
 use tree_sitter_graph::parse_error::ParseError;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::Identifier;
+use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 use tree_sitter_loader::Loader;
 
@@ -138,7 +139,7 @@ fn main() -> Result<()> {
     let functions = Functions::stdlib();
     let mut config = ExecutionConfig::new(&functions, &globals_).lazy(lazy);
     let graph = file
-        .execute(&tree, &source, &mut config)
+        .execute(&tree, &source, &mut config, &NoCancellation::default())
         .with_context(|| format!("Cannot execute TSG file {}", tsg_path.display()))?;
 
     let json = matches.is_present("json");

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -275,15 +275,16 @@ pub trait CancellationFlag {
     fn check(&self, at: &'static str) -> Result<(), CancellationError>;
 }
 
-pub struct NoCancellation;
-impl CancellationFlag for NoCancellation {
-    fn check(&self, _at: &'static str) -> Result<(), CancellationError> {
-        Ok(())
-    }
-}
-impl Default for NoCancellation {
-    fn default() -> Self {
-        Self
+pub struct CancellationFlags;
+impl CancellationFlags {
+    pub fn none() -> impl CancellationFlag {
+        struct NoCancellation;
+        impl CancellationFlag for NoCancellation {
+            fn check(&self, _at: &'static str) -> Result<(), CancellationError> {
+                Ok(())
+            }
+        }
+        NoCancellation
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -275,16 +275,10 @@ pub trait CancellationFlag {
     fn check(&self, at: &'static str) -> Result<(), CancellationError>;
 }
 
-pub struct CancellationFlags;
-impl CancellationFlags {
-    pub fn none() -> impl CancellationFlag {
-        struct NoCancellation;
-        impl CancellationFlag for NoCancellation {
-            fn check(&self, _at: &'static str) -> Result<(), CancellationError> {
-                Ok(())
-            }
-        }
-        NoCancellation
+pub struct NoCancellation;
+impl CancellationFlag for NoCancellation {
+    fn check(&self, _at: &'static str) -> Result<(), CancellationError> {
+        Ok(())
     }
 }
 

--- a/src/lazy_execution/statements.rs
+++ b/src/lazy_execution/statements.rs
@@ -31,6 +31,7 @@ pub(super) enum LazyStatement {
 
 impl LazyStatement {
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
+        exec.cancellation_flag.check("evaluating statement")?;
         debug!("eval {}", self);
         trace!("{{");
         let result = match self {

--- a/src/lazy_execution/values.rs
+++ b/src/lazy_execution/values.rs
@@ -118,6 +118,7 @@ impl From<LazyCall> for LazyValue {
 
 impl LazyValue {
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<Value, ExecutionError> {
+        exec.cancellation_flag.check("evaluating value")?;
         trace!("eval {} {{", self);
         let ret = match self {
             Self::Value(value) => Ok(value.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,9 @@ mod variables;
 
 pub use execution::CancellationError;
 pub use execution::CancellationFlag;
-pub use execution::CancellationFlags;
 pub use execution::ExecutionConfig;
 pub use execution::ExecutionError;
+pub use execution::NoCancellation;
 pub use parser::Location;
 pub use parser::ParseError;
 pub use variables::Globals as Variables;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,9 @@ mod variables;
 
 pub use execution::CancellationError;
 pub use execution::CancellationFlag;
+pub use execution::CancellationFlags;
 pub use execution::ExecutionConfig;
 pub use execution::ExecutionError;
-pub use execution::NoCancellation;
 pub use parser::Location;
 pub use parser::ParseError;
 pub use variables::Globals as Variables;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,11 @@ pub mod parse_error;
 mod parser;
 mod variables;
 
+pub use execution::CancellationError;
+pub use execution::CancellationFlag;
 pub use execution::ExecutionConfig;
 pub use execution::ExecutionError;
+pub use execution::NoCancellation;
 pub use parser::Location;
 pub use parser::ParseError;
 pub use variables::Globals as Variables;

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -9,10 +9,10 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
-use tree_sitter_graph::CancellationFlags;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
 use tree_sitter_graph::Identifier;
+use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -37,12 +37,7 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         .add(Identifier::from("filename"), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
     let mut config = ExecutionConfig::new(&functions, &globals);
-    let graph = file.execute(
-        &tree,
-        python_source,
-        &mut config,
-        &CancellationFlags::none(),
-    )?;
+    let graph = file.execute(&tree, python_source, &mut config, &NoCancellation)?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -12,6 +12,7 @@ use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
 use tree_sitter_graph::Identifier;
+use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -36,7 +37,12 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         .add(Identifier::from("filename"), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
     let mut config = ExecutionConfig::new(&functions, &globals);
-    let graph = file.execute(&tree, python_source, &mut config)?;
+    let graph = file.execute(
+        &tree,
+        python_source,
+        &mut config,
+        &NoCancellation::default(),
+    )?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -9,10 +9,10 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::CancellationFlags;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
 use tree_sitter_graph::Identifier;
-use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -41,7 +41,7 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         &tree,
         python_source,
         &mut config,
-        &NoCancellation::default(),
+        &CancellationFlags::none(),
     )?;
     let result = graph.pretty_print().to_string();
     Ok(result)

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -11,6 +11,7 @@ use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
+use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -35,7 +36,12 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         .add("filename".into(), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
     let mut config = ExecutionConfig::new(&functions, &globals).lazy(true);
-    let graph = file.execute(&tree, python_source, &mut config)?;
+    let graph = file.execute(
+        &tree,
+        python_source,
+        &mut config,
+        &NoCancellation::default(),
+    )?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -9,9 +9,9 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
-use tree_sitter_graph::CancellationFlags;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
+use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -36,12 +36,7 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         .add("filename".into(), "test.py".into())
         .map_err(|_| ExecutionError::DuplicateVariable("filename".into()))?;
     let mut config = ExecutionConfig::new(&functions, &globals).lazy(true);
-    let graph = file.execute(
-        &tree,
-        python_source,
-        &mut config,
-        &CancellationFlags::none(),
-    )?;
+    let graph = file.execute(&tree, python_source, &mut config, &NoCancellation)?;
     let result = graph.pretty_print().to_string();
     Ok(result)
 }

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -9,9 +9,9 @@ use indoc::indoc;
 use tree_sitter::Parser;
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
+use tree_sitter_graph::CancellationFlags;
 use tree_sitter_graph::ExecutionConfig;
 use tree_sitter_graph::ExecutionError;
-use tree_sitter_graph::NoCancellation;
 use tree_sitter_graph::Variables;
 
 fn init_log() {
@@ -40,7 +40,7 @@ fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionErr
         &tree,
         python_source,
         &mut config,
-        &NoCancellation::default(),
+        &CancellationFlags::none(),
     )?;
     let result = graph.pretty_print().to_string();
     Ok(result)


### PR DESCRIPTION
Add cancellation support.

This changes the API: `ast::File::execute` now has an extra parameter for the cancellation flag.

_Reviewers are encouraged to take a look at the other PRs listed in https://github.com/github/aleph/issues/1641 as well, to see how this design plays out through the whole stack._