### PR TITLE
Terminal coloring dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,10 @@ jobs:
           key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.OS }}-cargo-
-      - name: Build library
+      - name: Build library (default features)
         run: cargo build
+      - name: Build library (all features)
+        run: cargo build --all-features
       - name: Build program
         run: cargo build --bin tree-sitter-graph --features=cli
       - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,13 @@ jobs:
           key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.OS }}-cargo-
-      - name: Build & test library (default features)
+      - name: Build library (default features)
+        run: cargo build
+      - name: Test library (default features)
         run: cargo test
-      - name: Build & test library (all features)
+      - name: Build library (all features)
+        run: cargo build --all-features
+      - name: Test library (all features)
         run: cargo test --all-features
       - name: Build program
         run: cargo build --bin tree-sitter-graph --features=cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,9 @@ jobs:
           key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.OS }}-cargo-
-      - name: Build library (default features)
-        run: cargo build
-      - name: Build library (all features)
-        run: cargo build --all-features
+      - name: Build & test library (default features)
+        run: cargo test
+      - name: Build & test library (all features)
+        run: cargo test --all-features
       - name: Build program
         run: cargo build --bin tree-sitter-graph --features=cli
-      - name: Run test suite
-        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,7 @@ required-features = ["cli"]
 
 [features]
 cli = ["anyhow", "clap", "env_logger", "term-colors", "tree-sitter-config", "tree-sitter-loader"]
-term-colors = ["ansi_term"]
-
-[dependencies.ansi_term]
-optional = true
-version = "0.12"
+term-colors = ["colored"]
 
 [dependencies.anyhow]
 optional = true
@@ -55,6 +51,10 @@ version = "1.0"
 [dependencies.clap]
 optional = true
 version = "3.2"
+
+[dependencies.colored]
+optional = true
+version = "2"
 
 [dependencies.env_logger]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 test = false
 
 [dependencies]
-ansi_term = "0.12"
 log = "0.4"
 regex = "1"
 serde = "1.0"
@@ -42,7 +41,12 @@ name = "tree-sitter-graph"
 required-features = ["cli"]
 
 [features]
-cli = ["anyhow", "clap", "env_logger", "tree-sitter-config", "tree-sitter-loader"]
+cli = ["anyhow", "clap", "env_logger", "term-colors", "tree-sitter-config", "tree-sitter-loader"]
+term-colors = ["ansi_term"]
+
+[dependencies.ansi_term]
+optional = true
+version = "0.12"
 
 [dependencies.anyhow]
 optional = true

--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -6,7 +6,7 @@
 // ------------------------------------------------------------------------------------------------
 
 #[cfg(feature = "term-colors")]
-use ansi_term::Colour;
+use colored::Colorize;
 use std::path::Path;
 use thiserror::Error;
 
@@ -240,7 +240,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         fn blue<'a>(str: &'a str) -> impl std::fmt::Display {
             #[cfg(feature = "term-colors")]
             {
-                Colour::Blue.paint(str).to_string()
+                str.blue().to_string()
             }
             #[cfg(not(feature = "term-colors"))]
             {
@@ -250,7 +250,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         fn green_bold<'a>(str: &'a str) -> impl std::fmt::Display {
             #[cfg(feature = "term-colors")]
             {
-                Colour::Green.bold().paint(str).to_string()
+                str.green().bold().to_string()
             }
             #[cfg(not(feature = "term-colors"))]
             {
@@ -260,7 +260,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         fn white_bold<'a>(str: &'a str) -> impl std::fmt::Display {
             #[cfg(feature = "term-colors")]
             {
-                Colour::White.bold().paint(str).to_string()
+                str.white().bold()
             }
             #[cfg(not(feature = "term-colors"))]
             {

--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+#[cfg(feature = "term-colors")]
 use ansi_term::Colour;
 use std::path::Path;
 use thiserror::Error;
@@ -236,28 +237,53 @@ impl<'a> Excerpt<'a> {
 
 impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn blue<'a>(str: &'a str) -> impl std::fmt::Display {
+            #[cfg(feature = "term-colors")]
+            {
+                Colour::Blue.paint(str).to_string()
+            }
+            #[cfg(not(feature = "term-colors"))]
+            {
+                str.to_string()
+            }
+        }
+        fn green_bold<'a>(str: &'a str) -> impl std::fmt::Display {
+            #[cfg(feature = "term-colors")]
+            {
+                Colour::Green.bold().paint(str).to_string()
+            }
+            #[cfg(not(feature = "term-colors"))]
+            {
+                str.to_string()
+            }
+        }
+        fn white_bold<'a>(str: &'a str) -> impl std::fmt::Display {
+            #[cfg(feature = "term-colors")]
+            {
+                Colour::White.bold().paint(str).to_string()
+            }
+            #[cfg(not(feature = "term-colors"))]
+            {
+                str.to_string()
+            }
+        }
+
         // path and line/col
         writeln!(
             f,
             "{}{}:{}:{}:",
             " ".repeat(self.indent),
-            Colour::White
-                .bold()
-                .paint(self.path.to_str().unwrap_or("<unknown file>")),
-            Colour::White
-                .bold()
-                .paint(format!("{}", self.location.row + 1)),
-            Colour::White
-                .bold()
-                .paint(format!("{}", self.location.column + 1)),
+            white_bold(&self.path.to_str().unwrap_or("<unknown file>")),
+            white_bold(&format!("{}", self.location.row + 1)),
+            white_bold(&format!("{}", self.location.column + 1)),
         )?;
         // first line: line number & source
         writeln!(
             f,
             "{}{}{}{}",
             " ".repeat(self.indent),
-            Colour::Blue.paint(format!("{}", self.location.row + 1)),
-            Colour::Blue.paint(" | "),
+            blue(&format!("{}", self.location.row + 1)),
+            blue(" | "),
             self.source.unwrap_or("<no source found>"),
         )?;
         // second line: caret
@@ -266,9 +292,9 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
             "{}{}{}{}{}",
             " ".repeat(self.indent),
             " ".repeat(self.gutter_width()),
-            Colour::Blue.paint(" | "),
+            blue(" | "),
             " ".repeat(self.location.column),
-            Colour::Green.bold().paint("^")
+            green_bold("^")
         )?;
         Ok(())
     }

--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -237,37 +237,6 @@ impl<'a> Excerpt<'a> {
 
 impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fn blue<'a>(str: &'a str) -> impl std::fmt::Display {
-            #[cfg(feature = "term-colors")]
-            {
-                str.blue().to_string()
-            }
-            #[cfg(not(feature = "term-colors"))]
-            {
-                str.to_string()
-            }
-        }
-        fn green_bold<'a>(str: &'a str) -> impl std::fmt::Display {
-            #[cfg(feature = "term-colors")]
-            {
-                str.green().bold().to_string()
-            }
-            #[cfg(not(feature = "term-colors"))]
-            {
-                str.to_string()
-            }
-        }
-        fn white_bold<'a>(str: &'a str) -> impl std::fmt::Display {
-            #[cfg(feature = "term-colors")]
-            {
-                str.white().bold()
-            }
-            #[cfg(not(feature = "term-colors"))]
-            {
-                str.to_string()
-            }
-        }
-
         // path and line/col
         writeln!(
             f,
@@ -298,4 +267,33 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
         )?;
         Ok(())
     }
+}
+
+// coloring functions
+
+#[cfg(feature = "term-colors")]
+fn blue(str: &str) -> impl std::fmt::Display {
+    str.blue()
+}
+#[cfg(not(feature = "term-colors"))]
+fn blue<'a>(str: &'a str) -> impl std::fmt::Display + 'a {
+    str
+}
+
+#[cfg(feature = "term-colors")]
+fn green_bold(str: &str) -> impl std::fmt::Display {
+    str.green().bold()
+}
+#[cfg(not(feature = "term-colors"))]
+fn green_bold<'a>(str: &'a str) -> impl std::fmt::Display + 'a {
+    str
+}
+
+#[cfg(feature = "term-colors")]
+fn white_bold(str: &str) -> impl std::fmt::Display {
+    str.white().bold()
+}
+#[cfg(not(feature = "term-colors"))]
+fn white_bold<'a>(str: &'a str) -> impl std::fmt::Display + 'a {
+    str
 }


### PR DESCRIPTION
The `ansi_term` library used for terminal coloring is unmaintained: https://github.com/advisories/GHSA-74w3-p89x-ffgh.

This PR:
- Replaces it with the `colored` library.
- Puts terminal coloring behind the `term-colors` feature flag to reduce the number of required dependencies for library users.
- Adds a CI step that builds the project with all features enabled.
