### PR TITLE
Add action to publish crate on tag push

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,28 @@
+name: Publish on crates.io
+
+on:
+  push:
+    tags:
+      - v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Rust environment
+        uses: hecrj/setup-rust-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # TODO Verify the crate version matches the tag
+      - name: Verify publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          dry-run: true
+      - name: Publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This adds actions that publish the crate when a `v*` tag is pushed.

Docs for the publish action: https://github.com/marketplace/actions/publish-crates

It would be nice to verify that the tag matches the version of the crate, but I couldn't quickly figure out a way to do that.
