### PR TITLE
Various small improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tree-sitter/semantic-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Library
 
+#### Fixed
+
+- Query errors now report the correct column for errors on the first row of a query.
+
 #### Added
 
 - The `Variables` type has additional methods `is_empty` and `iter`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Library
+
+#### Added
+
+- The `Variables` type has additional methods `is_empty` and `iter`.
+
 ## 0.6.1 -- 2022-09-06
 
 ### Library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `Variables` type has additional methods `is_empty` and `iter`.
 
+#### Changed
+
+- References to `ExecutionConfig` passed to `File::execute*` are not required to be mutable anymore.
+
 ## 0.6.1 -- 2022-09-06
 
 ### Library

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -30,7 +30,7 @@ impl File {
         &self,
         tree: &'tree Tree,
         source: &'tree str,
-        config: &mut ExecutionConfig,
+        config: &ExecutionConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<Graph<'tree>, ExecutionError> {
         let mut graph = Graph::new();
@@ -48,7 +48,7 @@ impl File {
         graph: &mut Graph<'tree>,
         tree: &'tree Tree,
         source: &'tree str,
-        config: &mut ExecutionConfig,
+        config: &ExecutionConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), ExecutionError> {
         if config.lazy {

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -48,7 +48,7 @@ impl ast::File {
         graph: &mut Graph<'tree>,
         tree: &'tree Tree,
         source: &'tree str,
-        config: &mut ExecutionConfig,
+        config: &ExecutionConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), ExecutionError> {
         self.check_globals(config.globals)?;
@@ -104,7 +104,7 @@ impl ast::File {
 struct ExecutionContext<'a, 'c, 'g, 'tree> {
     source: &'tree str,
     graph: &'a mut Graph<'tree>,
-    config: &'a mut ExecutionConfig<'c, 'g>,
+    config: &'a ExecutionConfig<'c, 'g>,
     locals: &'a mut dyn MutVariables<LazyValue>,
     current_regex_captures: &'a Vec<String>,
     mat: &'a QueryMatch<'a, 'tree>,
@@ -142,7 +142,7 @@ impl ast::Stanza {
         source: &'tree str,
         mat: &QueryMatch<'_, 'tree>,
         graph: &mut Graph<'tree>,
-        config: &mut ExecutionConfig,
+        config: &ExecutionConfig,
         locals: &mut VariableMap<'l, LazyValue>,
         store: &mut LazyStore,
         scoped_store: &mut LazyScopedVariables,

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -69,7 +69,7 @@ impl File {
         graph: &mut Graph<'tree>,
         tree: &'tree Tree,
         source: &'tree str,
-        config: &mut ExecutionConfig,
+        config: &ExecutionConfig,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), ExecutionError> {
         self.check_globals(config.globals)?;
@@ -102,7 +102,7 @@ impl File {
 struct ExecutionContext<'a, 'c, 'g, 's, 'tree> {
     source: &'tree str,
     graph: &'a mut Graph<'tree>,
-    config: &'a mut ExecutionConfig<'c, 'g>,
+    config: &'a ExecutionConfig<'c, 'g>,
     locals: &'a mut dyn MutVariables<Value>,
     scoped: &'a mut ScopedVariables<'s>,
     current_regex_captures: &'a Vec<String>,
@@ -134,7 +134,7 @@ impl Stanza {
         tree: &'tree Tree,
         source: &'tree str,
         graph: &mut Graph<'tree>,
-        config: &mut ExecutionConfig<'_, 'g>,
+        config: &ExecutionConfig<'_, 'g>,
         locals: &mut VariableMap<'l, Value>,
         scoped: &mut ScopedVariables<'s>,
         current_regex_captures: &Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ pub use execution::NoCancellation;
 pub use parser::Location;
 pub use parser::ParseError;
 pub use variables::Globals as Variables;
+pub use variables::Iter as VariableIter;
+pub use variables::VariableError;
 
 use std::borrow::Borrow;
 use std::hash::Hash;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -291,6 +291,12 @@ impl<'a> Parser<'a> {
         self.query_source += &query_source;
         self.query_source += "\n";
         let query = Query::new(language, &query_source).map_err(|mut e| {
+            // the column of the first row of a query pattern must be shifted by the whitespace
+            // that was already consumed
+            if e.row == 0 {
+                // must come before we update e.row!
+                e.column += location.column;
+            }
             e.row += location.row;
             e.offset += query_start;
             e

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -166,9 +166,27 @@ impl<'a> Globals<'a> {
         self.values.remove(name);
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn iter<'b>(&'b self) -> Iter<'b> {
+        Iter(self.values.iter())
+    }
+
     /// Clears this enviroment.
     pub fn clear(&mut self) {
         self.values.clear();
+    }
+}
+
+pub struct Iter<'a>(std::collections::hash_map::Iter<'a, Identifier, Value>);
+
+impl<'a> std::iter::Iterator for Iter<'a> {
+    type Item = (&'a Identifier, &'a Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
     }
 }
 


### PR DESCRIPTION
One commit per item:

- [X] Add missing convenience methods for `Globals` type. It is really a map, but was lacking some basic map methods. Since this is a public type I think we should cover those.
- [X] Remove unnecessary `mut` for `ExecutionConfig` parameters.
- [X] #73
- [X] Add `CODEOWNERS` file so the team gets requested for reviews automatically.