### PR TITLE
Remove support for undeclared global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### DSL
+
+#### Removed
+
+- References to undefined variables now result in errors, instead of assuming its an undeclared global variable.
+
 ### Library
 
 #### Fixed

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -594,14 +594,6 @@ impl ast::UnscopedVariable {
             ctx.locals.get(&self.name)
         }
         .cloned()
-        // TODO deprecated support for undeclared globals
-        .or_else(|| {
-            eprintln!("Use of undeclared global variable {} is deprecated. Fix by adding an explicit declaration `global {}`", self.name, self.name);
-            Some(ExpressionResult {
-                quantifier: One,
-                is_local: true,
-            })
-        })
         .ok_or_else(|| CheckError::UndefinedVariable(self.name.as_str().to_string(), self.location))
     }
 }

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -1239,52 +1239,16 @@ fn can_parse_global() {
 }
 
 #[test]
-// TODO deprecated support for undeclared globals
-//      change to cannot_parse_undeclared_global once support is removed
-fn can_parse_undeclared_global() {
+fn cannot_parse_undeclared_global() {
     let source = r#"
         (identifier) {
           node n
           edge n -> root
         }
     "#;
-    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
-
-    assert_eq!(file.globals, vec![]);
-
-    let statements = file
-        .stanzas
-        .into_iter()
-        .map(|s| s.statements)
-        .collect::<Vec<_>>();
-    assert_eq!(
-        statements,
-        vec![vec![
-            CreateGraphNode {
-                node: UnscopedVariable {
-                    name: "n".into(),
-                    location: Location { row: 2, column: 15 },
-                }
-                .into(),
-                location: Location { row: 2, column: 10 },
-            }
-            .into(),
-            CreateEdge {
-                source: UnscopedVariable {
-                    name: "n".into(),
-                    location: Location { row: 3, column: 15 },
-                }
-                .into(),
-                sink: UnscopedVariable {
-                    name: "root".into(),
-                    location: Location { row: 3, column: 20 },
-                }
-                .into(),
-                location: Location { row: 3, column: 10 },
-            }
-            .into(),
-        ]]
-    );
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
+        panic!("Parse succeeded unexpectedly");
+    }
 }
 
 #[test]


### PR DESCRIPTION
References to undeclared variables were assumed to be undeclared globals, with only a warning printed to stderr. This removes that behavior and requires _all_ variables to be declared, either locally or as a global.

Fixes #105 and #75.

## Prerequisites

- [x] Depends on #108 