### PR TITLE
Add support for default string values for global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### DSL
 
+#### Added
+
+- Global variables can be given default string values using `global NAME = "STRING"` syntax.
+
 #### Removed
 
 - References to undefined variables now result in errors, instead of assuming its an undeclared global variable.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -50,6 +50,8 @@ pub struct Global {
     pub name: Identifier,
     /// The quantifier of the global variable
     pub quantifier: CaptureQuantifier,
+    /// Default value
+    pub default: Option<String>,
     pub location: Location,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -224,9 +224,16 @@ impl<'a> Parser<'a> {
         let location = self.location;
         let name = self.parse_identifier("global variable")?;
         let quantifier = self.parse_quantifier()?;
+        let mut default = None;
+        self.consume_whitespace();
+        if let Ok(_) = self.consume_token("=") {
+            self.consume_whitespace();
+            default = Some(self.parse_string()?);
+        }
         Ok(ast::Global {
             name,
             quantifier,
+            default,
             location,
         })
     }

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -271,6 +271,26 @@ fn can_use_global_variable() {
 }
 
 #[test]
+fn can_omit_global_variable_with_default() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          global pkgname = ""
+
+          (module) @root
+          {
+            node n
+            attr (n) pkgname = pkgname
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            pkgname: ""
+    "#},
+    );
+}
+
+#[test]
 fn cannot_omit_global_variable() {
     fail_execution(
         "pass",

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -272,6 +272,26 @@ fn can_use_global_variable() {
 }
 
 #[test]
+fn can_omit_global_variable_with_default() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          global pkgname = ""
+
+          (module) @root
+          {
+            node n
+            attr (n) pkgname = pkgname
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            pkgname: ""
+    "#},
+    );
+}
+
+#[test]
 fn cannot_omit_global_variable() {
     fail_execution(
         "pass",

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -1199,6 +1199,7 @@ fn can_parse_global() {
         vec![Global {
             name: "root".into(),
             quantifier: One,
+            default: None,
             location: Location { row: 1, column: 15 },
         }]
     );
@@ -1239,6 +1240,46 @@ fn can_parse_global() {
 }
 
 #[test]
+fn can_parse_global_with_default() {
+    let source = r#"
+        global PKG_NAME = ""
+
+        (identifier) {
+          print PKG_NAME
+        }
+    "#;
+    let file = File::from_str(tree_sitter_python::language(), source).expect("Cannot parse file");
+
+    assert_eq!(
+        file.globals,
+        vec![Global {
+            name: "PKG_NAME".into(),
+            quantifier: One,
+            default: Some("".into()),
+            location: Location { row: 1, column: 15 },
+        }]
+    );
+
+    let statements = file
+        .stanzas
+        .into_iter()
+        .map(|s| s.statements)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        statements,
+        vec![vec![Print {
+            values: vec![UnscopedVariable {
+                name: "PKG_NAME".into(),
+                location: Location { row: 4, column: 16 }
+            }
+            .into()],
+            location: Location { row: 4, column: 10 },
+        }
+        .into()]]
+    );
+}
+
+#[test]
 fn cannot_parse_undeclared_global() {
     let source = r#"
         (identifier) {
@@ -1270,6 +1311,7 @@ fn can_parse_list_global() {
         vec![Global {
             name: "roots".into(),
             quantifier: ZeroOrMore,
+            default: None,
             location: Location { row: 1, column: 15 },
         }]
     );
@@ -1342,6 +1384,7 @@ fn can_parse_optional_global() {
         vec![Global {
             name: "root".into(),
             quantifier: ZeroOrOne,
+            default: None,
             location: Location { row: 1, column: 15 },
         }]
     );


### PR DESCRIPTION
Adds support for default string values for global variables. For example:

    global PKG_NAME = ""

Do we want to allow more types of values? A more flexible design (but more invasive change) would be to allow arbitrary expressions, so that you can write something like:

    global FILE_NAME = ""
    global MODULE_NAME = (replace "/" "." FILE_NAME)

Fixes #104.

## Prerequisites

- [ ] Depends on #109.

