### PR TITLE
Add Zenodo citation file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,18 @@
+{
+    "creators": [
+        {
+            "orcid": "0000-0001-5117-0921",
+            "name": "van Antwerpen, Hendrik",
+            "affiliation": "GitHub"
+        },
+        {
+            "name": "Rix, Rob",
+            "affiliation": "GitHub"
+        },
+        {
+            "orcid": "0000-0003-1100-4894",
+            "name": "Creager, Douglas A.",
+            "affiliation": "GitHub"
+        }
+    ]
+}


### PR DESCRIPTION
Once the first release shows up and we have a DOI, I'll also add (in a separate PR) a `CITATION.cff` file that GitHub will render.