### PR TITLE
Add job to create GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,16 @@
-name: Publish on crates.io
+name: Publish release
 
 on:
   push:
     tags:
-      - v*'
+      - v*
 
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
 
 jobs:
-  publish:
+  publish-crate:
     runs-on: ubuntu-latest
     steps:
       - name: Install Rust environment
@@ -26,3 +26,14 @@ jobs:
         uses: katyo/publish-crates@v1
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,12 @@ on:
     tags:
       - v*
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-
 jobs:
   publish-crate:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: 0
     steps:
       - name: Install Rust environment
         uses: hecrj/setup-rust-action@v1


### PR DESCRIPTION
This adds an workflow to create a GitHub release whenever a new version tag is pushed.

Action docs: https://github.com/marketplace/actions/create-release

Depends on #113.