### PR TITLE
Fixes for error reporting

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -62,6 +62,8 @@ pub struct Stanza {
     pub query: Query,
     /// The list of statements in the stanza
     pub statements: Vec<Statement>,
+    /// Capture index of the full match in the stanza query
+    pub full_match_stanza_capture_index: usize,
     /// Capture index of the full match in the file query
     pub full_match_file_capture_index: usize,
     pub location: Location,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -104,7 +104,9 @@ impl ast::Stanza {
             locals: &mut locals,
         };
         self.full_match_file_capture_index =
-            ctx.file_query.capture_index_for_name(FULL_MATCH).unwrap() as usize;
+            ctx.file_query
+                .capture_index_for_name(FULL_MATCH)
+                .expect("missing capture index for full match") as usize;
         for statement in &mut self.statements {
             statement.check(&mut ctx)?;
         }
@@ -471,7 +473,10 @@ impl ast::Capture {
             .capture_index_for_name(&name)
             .ok_or_else(|| CheckError::UndefinedSyntaxCapture(name.clone(), self.location))?
             as usize;
-        self.file_capture_index = ctx.file_query.capture_index_for_name(&name).unwrap() as usize;
+        self.file_capture_index = ctx
+            .file_query
+            .capture_index_for_name(&name)
+            .expect("missing capture index for name") as usize; // if the previous lookup succeeded, this one should succeed as well
         self.quantifier =
             ctx.file_query.capture_quantifiers(ctx.stanza_index)[self.file_capture_index];
         Ok(ExpressionResult {

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -169,9 +169,9 @@ pub(self) fn query_capture_value<'tree>(
         .filter(|c| c.index as usize == index)
         .map(|c| c.node);
     match quantifier {
-        CaptureQuantifier::Zero => panic!("Capture with quantifier 0 has no value"),
+        CaptureQuantifier::Zero => unreachable!(),
         CaptureQuantifier::One => {
-            let syntax_node = graph.add_syntax_node(nodes.next().unwrap());
+            let syntax_node = graph.add_syntax_node(nodes.next().expect("missing capture"));
             syntax_node.into()
         }
         CaptureQuantifier::ZeroOrMore | CaptureQuantifier::OneOrMore => {

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -190,7 +190,7 @@ impl ast::Stanza {
                     .captures
                     .iter()
                     .find(|c| c.index as usize == self.full_match_file_capture_index)
-                    .unwrap()
+                    .expect("missing capture for full match")
                     .node;
                 Context::Statement {
                     statement: format!("{}", statement),
@@ -308,7 +308,12 @@ impl ast::Scan {
                 exec.cancellation_flag.check("processing scan matches")?;
                 let captures = arm.regex.captures(&match_string[i..]);
                 if let Some(captures) = captures {
-                    if captures.get(0).unwrap().range().is_empty() {
+                    if captures
+                        .get(0)
+                        .expect("missing regex capture")
+                        .range()
+                        .is_empty()
+                    {
                         return Err(ExecutionError::EmptyRegexCapture(format!(
                             "for regular expression /{}/",
                             arm.regex
@@ -323,7 +328,7 @@ impl ast::Scan {
             }
 
             matches.sort_by_key(|(captures, index)| {
-                let range = captures.get(0).unwrap().range();
+                let range = captures.get(0).expect("missing regex capture").range();
                 (range.start, *index)
             });
 
@@ -369,7 +374,11 @@ impl ast::Scan {
                     })?;
             }
 
-            i += regex_captures.get(0).unwrap().range().end;
+            i += regex_captures
+                .get(0)
+                .expect("missing regex capture")
+                .range()
+                .end;
         }
 
         Ok(())

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -174,7 +174,7 @@ impl Stanza {
                     let node = mat
                         .captures
                         .iter()
-                        .find(|c| c.index as usize == self.full_match_file_capture_index)
+                        .find(|c| c.index as usize == self.full_match_stanza_capture_index)
                         .unwrap()
                         .node;
                     Context::Statement {

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -175,7 +175,7 @@ impl Stanza {
                         .captures
                         .iter()
                         .find(|c| c.index as usize == self.full_match_stanza_capture_index)
-                        .unwrap()
+                        .expect("missing capture for full match")
                         .node;
                     Context::Statement {
                         statement: format!("{}", statement),
@@ -330,7 +330,12 @@ impl Scan {
             for (index, arm) in self.arms.iter().enumerate() {
                 let captures = arm.regex.captures(&match_string[i..]);
                 if let Some(captures) = captures {
-                    if captures.get(0).unwrap().range().is_empty() {
+                    if captures
+                        .get(0)
+                        .expect("missing regex capture")
+                        .range()
+                        .is_empty()
+                    {
                         return Err(ExecutionError::EmptyRegexCapture(format!(
                             "for regular expression /{}/",
                             arm.regex
@@ -345,7 +350,7 @@ impl Scan {
             }
 
             matches.sort_by_key(|(captures, index)| {
-                let range = captures.get(0).unwrap().range();
+                let range = captures.get(0).expect("missing regex capture").range();
                 (range.start, *index)
             });
 
@@ -385,7 +390,11 @@ impl Scan {
                     })?;
             }
 
-            i += regex_captures.get(0).unwrap().range().end;
+            i += regex_captures
+                .get(0)
+                .expect("missing regex capture")
+                .range()
+                .end;
         }
 
         Ok(())

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -100,7 +100,11 @@ impl std::fmt::Display for ParseErrorDisplay<'_> {
                 let text = &self.source[node.start_byte()..end_byte];
                 write!(f, ": {}", text)?;
             } else {
-                let text = self.source.lines().nth(line).unwrap();
+                let text = self
+                    .source
+                    .lines()
+                    .nth(line)
+                    .expect("parse error has invalid row");
                 writeln!(f, ":")?;
                 writeln!(f, "")?;
                 writeln!(f, "| {}", text)?;


### PR DESCRIPTION
This addresses two issues with error reporting:

1. Some errors during strict evaluation cause panics during error formatting. The problem was a use of the wrong index.

2. Several `unwrap` calls are replaced by `expect` to make debugging easier when similar problems are reported.