### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 -- 2023-03-29
+
+### Library
+
+#### Fixed
+
+- Fix error formatting panic with strict execution.
+
+#### Changed
+
+- The traits stored in `Functions` must now implement `Send` and `Sync` to ensure they can be shared more easily in concurrent situations.
+
 ## 0.7.0 -- 2022-10-18
 
 ### DSL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.7.0"
+version = "0.8.0"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use it as a library, add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
-tree-sitter-graph = "0.7"
+tree-sitter-graph = "0.8"
 ```
 
 To use it as a program, install it via `cargo install`:


### PR DESCRIPTION
A small release with some useful fixes. It is a minor release becaus the extra trait bounds introduced in #122 might break existing code (although not very likely given the `'static` lifetime requirement).