### PR TITLE
Pretty errors for lazy execution

### DIFF
--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -266,7 +266,7 @@ impl<'a> Excerpt<'a> {
 impl<'a> std::fmt::Display for Excerpt<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         // path and line/col
-        writeln!(
+        write!(
             f,
             "{}{}:{}:{}:",
             " ".repeat(self.indent),
@@ -275,6 +275,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
             white_bold(&format!("{}", self.location.column + 1)),
         )?;
         if let Some(source) = self.source {
+            writeln!(f)?;
             // first line: line number & source
             writeln!(
                 f,
@@ -295,7 +296,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
                 green_bold("^")
             )?;
         } else {
-            writeln!(f, "{}{}", " ".repeat(self.indent), "<missing source>",)?;
+            writeln!(f, " <missing source>")?;
         }
         Ok(())
     }

--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -151,7 +151,10 @@ impl<R> ResultWithExecutionError<R> for Result<R, ExecutionError> {
     {
         self.map_err(|e| match e {
             cancelled @ ExecutionError::Cancelled(_) => cancelled,
-            in_context @ ExecutionError::InContext(_, _) => in_context,
+            in_other_context @ ExecutionError::InContext(Context::Other(_), _) => {
+                ExecutionError::InContext(with_context(), Box::new(in_other_context))
+            }
+            in_stmt_context @ ExecutionError::InContext(_, _) => in_stmt_context,
             _ => ExecutionError::InContext(with_context(), Box::new(e)),
         })
     }

--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -274,25 +274,29 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
             white_bold(&format!("{}", self.location.row + 1)),
             white_bold(&format!("{}", self.location.column + 1)),
         )?;
-        // first line: line number & source
-        writeln!(
-            f,
-            "{}{}{}{}",
-            " ".repeat(self.indent),
-            blue(&format!("{}", self.location.row + 1)),
-            blue(" | "),
-            self.source.unwrap_or("<no source found>"),
-        )?;
-        // second line: caret
-        writeln!(
-            f,
-            "{}{}{}{}{}",
-            " ".repeat(self.indent),
-            " ".repeat(self.gutter_width()),
-            blue(" | "),
-            " ".repeat(self.location.column),
-            green_bold("^")
-        )?;
+        if let Some(source) = self.source {
+            // first line: line number & source
+            writeln!(
+                f,
+                "{}{}{}{}",
+                " ".repeat(self.indent),
+                blue(&format!("{}", self.location.row + 1)),
+                blue(" | "),
+                source,
+            )?;
+            // second line: caret
+            writeln!(
+                f,
+                "{}{}{}{}{}",
+                " ".repeat(self.indent),
+                " ".repeat(self.gutter_width()),
+                blue(" | "),
+                " ".repeat(self.location.column),
+                green_bold("^")
+            )?;
+        } else {
+            writeln!(f, "{}{}", " ".repeat(self.indent), "<missing source>",)?;
+        }
         Ok(())
     }
 }

--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -10,6 +10,7 @@ use colored::Colorize;
 use std::path::Path;
 use thiserror::Error;
 
+use crate::ast::{Stanza, Statement};
 use crate::execution::CancellationError;
 use crate::Location;
 
@@ -87,6 +88,23 @@ pub struct StatementContext {
     pub stanza_location: Location,
     pub source_location: Location,
     pub node_kind: String,
+}
+
+impl StatementContext {
+    pub(crate) fn new(stmt: &Statement, stanza: &Stanza, source_node: &tree_sitter::Node) -> Self {
+        Self {
+            statement: format!("{}", stmt),
+            statement_location: stmt.location(),
+            stanza_location: stanza.location,
+            source_location: Location::from(source_node.range().start_point),
+            node_kind: source_node.kind().to_string(),
+        }
+    }
+
+    pub(crate) fn update_statement(&mut self, stmt: &Statement) {
+        self.statement = format!("{}", stmt);
+        self.statement_location = stmt.location();
+    }
 }
 
 impl From<StatementContext> for Context {

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -42,7 +42,6 @@ use crate::ast::Statement;
 use crate::ast::StringConstant;
 use crate::ast::UnscopedVariable;
 use crate::ast::Variable;
-use crate::execution::error::Context;
 use crate::execution::error::ExecutionError;
 use crate::execution::error::ResultWithExecutionError;
 use crate::execution::query_capture_value;
@@ -58,6 +57,8 @@ use crate::variables::VariableMap;
 use crate::variables::Variables;
 use crate::Identifier;
 use crate::Location;
+
+use super::error::StatementContext;
 
 impl File {
     /// Executes this graph DSL file against a source file, saving the results into an existing
@@ -177,13 +178,14 @@ impl Stanza {
                         .find(|c| c.index as usize == self.full_match_stanza_capture_index)
                         .expect("missing capture for full match")
                         .node;
-                    Context::Statement {
+                    StatementContext {
                         statement: format!("{}", statement),
                         statement_location: statement.location(),
                         stanza_location: self.location,
                         source_location: Location::from(node.range().start_point),
                         node_kind: node.kind().to_string(),
                     }
+                    .into()
                 })?;
             }
         }


### PR DESCRIPTION
Strict execution has had pretty errors with source excerpts for some time now. This PR makes the changes to support the same for lazy execution. This is useful because the tree-sitter-stack-graphs tool uses lazy execution.
