### PR TITLE
Print parse errors same as execution errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Library
+
+#### Changed
+
+- The method `ParseError::display(source: &str, verbose: bool)` has been replaced by two methods `ParseError::display(path: &path, source: &str)` and `ParseError::display_pretty(path: &Path, source: &str)`.
+
+### CLI
+
+#### Changed
+
+- Parse errors are now displayed with the same excerpt style as execution errors.
+
 ## 0.8.0 -- 2023-03-29
 
 ### Library

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -114,15 +114,7 @@ fn main() -> Result<()> {
         let parse_errors = ParseError::all(&tree);
         if !parse_errors.is_empty() {
             for parse_error in parse_errors.iter().take(MAX_PARSE_ERRORS) {
-                let line = parse_error.node().start_position().row;
-                let column = parse_error.node().start_position().column;
-                eprintln!(
-                    "{}:{}:{}: {}",
-                    source_path.display(),
-                    line + 1,
-                    column + 1,
-                    parse_error.display(&source, true)
-                );
+                eprintln!("{}", parse_error.display_pretty(source_path, &source));
             }
             if parse_errors.len() > MAX_PARSE_ERRORS {
                 let more_errors = parse_errors.len() - MAX_PARSE_ERRORS;
@@ -141,7 +133,7 @@ fn main() -> Result<()> {
     let graph = match file.execute(&tree, &source, &mut config, &NoCancellation) {
         Ok(graph) => graph,
         Err(e) => {
-            eprint!("{}", e.display_pretty(source_path, &source, tsg_path, &tsg));
+            eprintln!("{}", e.display_pretty(source_path, &source, tsg_path, &tsg));
             return Err(anyhow!("Cannot execute TSG file {}", tsg_path.display()));
         }
     };

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -7,6 +7,10 @@
 
 //! Data types and functions for finding and displaying tree-sitter parse errors.
 
+#[cfg(feature = "term-colors")]
+use colored::Colorize;
+use std::ops::Range;
+use std::path::Path;
 use tree_sitter::Node;
 use tree_sitter::Tree;
 
@@ -57,7 +61,11 @@ impl<'tree> ParseError<'tree> {
         }
     }
 
-    pub fn display(&self, source: &'tree str, verbose: bool) -> ParseErrorDisplay {
+    pub fn display<'a: 'tree>(
+        &'a self,
+        source: &'tree str,
+        verbose: bool,
+    ) -> impl std::fmt::Display + 'a + 'tree {
         ParseErrorDisplay {
             error: self,
             source,
@@ -66,7 +74,7 @@ impl<'tree> ParseError<'tree> {
     }
 }
 
-pub struct ParseErrorDisplay<'tree> {
+struct ParseErrorDisplay<'tree> {
     error: &'tree ParseError<'tree>,
     source: &'tree str,
     verbose: bool,
@@ -308,3 +316,103 @@ impl std::fmt::Debug for TreeWithParseErrorVec {
 // This is okay because Send and Sync _are_ implemented for Tree, which also holds ffi::TSTree
 unsafe impl Send for TreeWithParseErrorVec {}
 unsafe impl Sync for TreeWithParseErrorVec {}
+
+//-----------------------------------------------------------------------------
+
+/// Excerpts of source from either the target language file or the tsg rules file.
+pub(crate) struct Excerpt<'a> {
+    path: &'a Path,
+    source: Option<&'a str>,
+    row: usize,
+    columns: Range<usize>,
+    indent: usize,
+}
+
+impl<'a> Excerpt<'a> {
+    pub fn from_source(
+        path: &'a Path,
+        source: &'a str,
+        row: usize,
+        columns: Range<usize>,
+        indent: usize,
+    ) -> Excerpt<'a> {
+        Excerpt {
+            path,
+            source: source.lines().nth(row),
+            row,
+            columns,
+            indent,
+        }
+    }
+
+    fn gutter_width(&self) -> usize {
+        ((self.row + 1) as f64).log10() as usize + 1
+    }
+}
+
+impl<'a> std::fmt::Display for Excerpt<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // path and line/col
+        writeln!(
+            f,
+            "{}{}:{}:{}:",
+            " ".repeat(self.indent),
+            white_bold(&self.path.to_str().unwrap_or("<unknown file>")),
+            white_bold(&format!("{}", self.row + 1)),
+            white_bold(&format!("{}", self.columns.start + 1)),
+        )?;
+        if let Some(source) = self.source {
+            // first line: line number & source
+            writeln!(
+                f,
+                "{}{}{}{}",
+                " ".repeat(self.indent),
+                blue(&format!("{}", self.row + 1)),
+                blue(" | "),
+                source,
+            )?;
+            // second line: caret
+            writeln!(
+                f,
+                "{}{}{}{}{}",
+                " ".repeat(self.indent),
+                " ".repeat(self.gutter_width()),
+                blue(" | "),
+                " ".repeat(self.columns.start),
+                green_bold(&"^".repeat(self.columns.len()))
+            )?;
+        } else {
+            writeln!(f, "{}{}", " ".repeat(self.indent), "<missing source>",)?;
+        }
+        Ok(())
+    }
+}
+
+// coloring functions
+
+#[cfg(feature = "term-colors")]
+fn blue(str: &str) -> impl std::fmt::Display {
+    str.blue()
+}
+#[cfg(not(feature = "term-colors"))]
+fn blue<'a>(str: &'a str) -> impl std::fmt::Display + 'a {
+    str
+}
+
+#[cfg(feature = "term-colors")]
+fn green_bold(str: &str) -> impl std::fmt::Display {
+    str.green().bold()
+}
+#[cfg(not(feature = "term-colors"))]
+fn green_bold<'a>(str: &'a str) -> impl std::fmt::Display + 'a {
+    str
+}
+
+#[cfg(feature = "term-colors")]
+fn white_bold(str: &str) -> impl std::fmt::Display {
+    str.white().bold()
+}
+#[cfg(not(feature = "term-colors"))]
+fn white_bold<'a>(str: &'a str) -> impl std::fmt::Display + 'a {
+    str
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@
 
 use std::fmt::Display;
 use std::iter::Peekable;
+use std::ops::Range;
 use std::str::Chars;
 
 use regex::Regex;
@@ -91,6 +92,10 @@ impl Location {
         } else {
             self.column += 1;
         }
+    }
+
+    pub(crate) fn to_column_range(&self) -> Range<usize> {
+        self.column..self.column + 1
     }
 }
 


### PR DESCRIPTION
This reuses the Excerpt type for formatting of parse errors. They will now have the same style as execution errors.

It also changes the `display` method to include that path, and moves verbose formatting to a dedicated `display_pretty` method.
