### PR TITLE
Patch release with improved error formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### CLI
+
+#### Added
+
+- Errors from parsing and checking the TSG file are now displayed with source excerpts.
+
 ## v0.9.0 -- 2023-03-31
 
 ### Library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.9.1 -- 2023-04-03
 
 ### CLI
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.9.0"
+version = "0.9.1"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -98,8 +98,13 @@ fn main() -> Result<()> {
     let tsg = std::fs::read(tsg_path)
         .with_context(|| format!("Cannot read TSG file {}", tsg_path.display()))?;
     let tsg = String::from_utf8(tsg)?;
-    let file = File::from_str(language, &tsg)
-        .with_context(|| format!("Cannot parsing TSG file {}", tsg_path.display()))?;
+    let file = match File::from_str(language, &tsg) {
+        Ok(file) => file,
+        Err(err) => {
+            eprintln!("{}", err.display_pretty(tsg_path, &tsg));
+            return Err(anyhow!("Cannot parse TSG file {}", tsg_path.display()));
+        }
+    };
 
     let source = std::fs::read(source_path)
         .with_context(|| format!("Cannot read source file {}", source_path.display()))?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -125,7 +125,6 @@ impl std::fmt::Display for DisplayParseErrorPretty<'_> {
                 return Ok(());
             }
         };
-        writeln!(f, "{}", self.source)?;
         writeln!(f, "{}", self.error)?;
         write!(
             f,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,7 @@
 use std::fmt::Display;
 use std::iter::Peekable;
 use std::ops::Range;
+use std::path::Path;
 use std::str::Chars;
 
 use regex::Regex;
@@ -23,6 +24,7 @@ use tree_sitter::Query;
 use tree_sitter::QueryError;
 
 use crate::ast;
+use crate::parse_error::Excerpt;
 use crate::Identifier;
 
 pub const FULL_MATCH: &str = "__tsg__full_match";
@@ -45,6 +47,9 @@ impl ast::File {
         Parser::new(content).parse_into_file(self)
     }
 }
+
+// ----------------------------------------------------------------------------
+// Parse errors
 
 /// An error that can occur while parsing a graph DSL file
 #[derive(Debug, Error)]
@@ -77,6 +82,69 @@ pub enum ParseError {
     Check(#[from] crate::checker::CheckError),
 }
 
+impl ParseError {
+    pub fn display_pretty<'a>(
+        &'a self,
+        path: &'a Path,
+        source: &'a str,
+    ) -> impl std::fmt::Display + 'a {
+        DisplayParseErrorPretty {
+            error: self,
+            path,
+            source,
+        }
+    }
+}
+
+struct DisplayParseErrorPretty<'a> {
+    error: &'a ParseError,
+    path: &'a Path,
+    source: &'a str,
+}
+
+impl std::fmt::Display for DisplayParseErrorPretty<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let location = match self.error {
+            ParseError::ExpectedQuantifier(location) => *location,
+            ParseError::ExpectedToken(_, location) => *location,
+            ParseError::ExpectedVariable(location) => *location,
+            ParseError::ExpectedUnscopedVariable(location) => *location,
+            ParseError::InvalidRegex(_, location) => *location,
+            ParseError::InvalidRegexCapture(location) => *location,
+            ParseError::QueryError(err) => Location {
+                row: err.row,
+                column: err.column,
+            },
+            ParseError::UnexpectedCharacter(_, _, location) => *location,
+            ParseError::UnexpectedEOF(location) => *location,
+            ParseError::UnexpectedKeyword(_, location) => *location,
+            ParseError::UnexpectedLiteral(_, location) => *location,
+            ParseError::UnexpectedQueryPatterns(location) => *location,
+            ParseError::Check(err) => {
+                write!(f, "{}", err.display_pretty(self.path, self.source))?;
+                return Ok(());
+            }
+        };
+        writeln!(f, "{}", self.source)?;
+        writeln!(f, "{}", self.error)?;
+        write!(
+            f,
+            "{}",
+            Excerpt::from_source(
+                self.path,
+                self.source,
+                location.row,
+                location.to_column_range(),
+                0
+            )
+        )?;
+        Ok(())
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Location
+
 /// The location of a graph DSL entity within its file
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Location {
@@ -104,6 +172,9 @@ impl Display for Location {
         write!(f, "({}, {})", self.row + 1, self.column + 1)
     }
 }
+
+// ----------------------------------------------------------------------------
+// Parser
 
 struct Parser<'a> {
     source: &'a str,


### PR DESCRIPTION
Errors resulting from parsing the TSG file (not the source file) were not formatted nicely yet. This PR ensures these errors are reported to the console with source fragments, like most other errors.

It also bumps the patch version so we can depend on this.

_Example output:_

```
$ cargo run --features cli -- invalid.tsg valid.ts 
Undefined syntax capture @prog at (1, 13)
invalid.tsg:1:13:
1 | (_) { print @prog }
  |             ^

Error: Cannot parse TSG file invalid.tsg
```
