### PR TITLE
Make `Excerpt` type public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.9.2 -- 2023-04-14
+
+### Library
+
+#### Added
+
+- The `parse_error::Excerpt` type, which is used to show source excerpts, is now public.
+
 ## v0.9.1 -- 2023-04-03
 
 ### CLI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.9.1"
+version = "0.9.2"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -370,12 +370,14 @@ impl<'a> Excerpt<'a> {
         path: &'a Path,
         source: &'a str,
         row: usize,
-        columns: Range<usize>,
+        mut columns: Range<usize>,
         indent: usize,
     ) -> Excerpt<'a> {
+        let source = source.lines().nth(row);
+        columns.end = std::cmp::min(columns.end, source.map(|s| s.len()).unwrap_or_default());
         Excerpt {
             path,
-            source: source.lines().nth(row),
+            source,
             row,
             columns,
             indent,

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -357,7 +357,7 @@ unsafe impl Sync for TreeWithParseErrorVec {}
 //-----------------------------------------------------------------------------
 
 /// Excerpts of source from either the target language file or the tsg rules file.
-pub(crate) struct Excerpt<'a> {
+pub struct Excerpt<'a> {
     path: &'a Path,
     source: Option<&'a str>,
     row: usize,

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -394,7 +394,7 @@ impl<'a> std::fmt::Display for Excerpt<'a> {
             f,
             "{}{}:{}:{}:",
             " ".repeat(self.indent),
-            white_bold(&self.path.to_str().unwrap_or("<unknown file>")),
+            white_bold(&self.path.to_string_lossy()),
             white_bold(&format!("{}", self.row + 1)),
             white_bold(&format!("{}", self.columns.start + 1)),
         )?;


### PR DESCRIPTION
The `Excerpt` type, which is used to display source snippets in errors, is made public. This makes it easy for downstream users to display source fragments in the same style, without having to reimplement anything.

Also bumps the patch version so we can depend on it.
