### PR TITLE
Fixes to error reporting

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -478,17 +478,17 @@ impl ast::Expression {
             Self::FalseLiteral => Ok(ExpressionResult {
                 is_local: true,
                 quantifier: One,
-                used_captures: HashSet::new(),
+                used_captures: HashSet::default(),
             }),
             Self::NullLiteral => Ok(ExpressionResult {
                 is_local: true,
                 quantifier: One,
-                used_captures: HashSet::new(),
+                used_captures: HashSet::default(),
             }),
             Self::TrueLiteral => Ok(ExpressionResult {
                 is_local: true,
                 quantifier: One,
-                used_captures: HashSet::new(),
+                used_captures: HashSet::default(),
             }),
             Self::IntegerConstant(expr) => expr.check(ctx),
             Self::StringConstant(expr) => expr.check(ctx),
@@ -509,7 +509,7 @@ impl ast::IntegerConstant {
         Ok(ExpressionResult {
             is_local: true,
             quantifier: One,
-            used_captures: HashSet::new(),
+            used_captures: HashSet::default(),
         })
     }
 }
@@ -519,7 +519,7 @@ impl ast::StringConstant {
         Ok(ExpressionResult {
             is_local: true,
             quantifier: One,
-            used_captures: HashSet::new(),
+            used_captures: HashSet::default(),
         })
     }
 }
@@ -676,7 +676,7 @@ impl ast::RegexCapture {
         Ok(ExpressionResult {
             is_local: true,
             quantifier: One,
-            used_captures: HashSet::new(),
+            used_captures: HashSet::default(),
         })
     }
 }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -170,8 +170,10 @@ impl ast::Stanza {
 //-----------------------------------------------------------------------------
 // Statements
 
+type StatementResult = ();
+
 impl ast::Statement {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         match self {
             Self::DeclareImmutable(stmt) => stmt.check(ctx),
             Self::DeclareMutable(stmt) => stmt.check(ctx),
@@ -189,7 +191,7 @@ impl ast::Statement {
 }
 
 impl ast::DeclareImmutable {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         let value = self.value.check(ctx)?;
         self.variable.check_add(ctx, value, false)?;
         Ok(())
@@ -197,7 +199,7 @@ impl ast::DeclareImmutable {
 }
 
 impl ast::DeclareMutable {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         let value = self.value.check(ctx)?;
         self.variable.check_add(ctx, value, true)?;
         Ok(())
@@ -205,7 +207,7 @@ impl ast::DeclareMutable {
 }
 
 impl ast::Assign {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         let value = self.value.check(ctx)?;
         self.variable.check_set(ctx, value)?;
         Ok(())
@@ -213,7 +215,7 @@ impl ast::Assign {
 }
 
 impl ast::CreateGraphNode {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         self.node.check_add(
             ctx,
             ExpressionResult {
@@ -227,7 +229,7 @@ impl ast::CreateGraphNode {
 }
 
 impl ast::AddGraphNodeAttribute {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         self.node.check(ctx)?;
         for attribute in &mut self.attributes {
             attribute.check(ctx)?;
@@ -237,7 +239,7 @@ impl ast::AddGraphNodeAttribute {
 }
 
 impl ast::CreateEdge {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         self.source.check(ctx)?;
         self.sink.check(ctx)?;
         Ok(())
@@ -245,7 +247,7 @@ impl ast::CreateEdge {
 }
 
 impl ast::AddEdgeAttribute {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         self.source.check(ctx)?;
         self.sink.check(ctx)?;
         for attribute in &mut self.attributes {
@@ -256,7 +258,7 @@ impl ast::AddEdgeAttribute {
 }
 
 impl ast::Scan {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         let value_result = self.value.check(ctx)?;
         if !value_result.is_local {
             return Err(CheckError::ExpectedLocalValue(self.location));
@@ -293,7 +295,7 @@ impl ast::Scan {
 }
 
 impl ast::Print {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         for value in &mut self.values {
             value.check(ctx)?;
         }
@@ -302,7 +304,7 @@ impl ast::Print {
 }
 
 impl ast::If {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         for arm in &mut self.arms {
             for condition in &mut arm.conditions {
                 condition.check(ctx)?;
@@ -326,7 +328,7 @@ impl ast::If {
 }
 
 impl ast::Condition {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         match self {
             Self::None { value, location } | Self::Some { value, location } => {
                 let value_result = value.check(ctx)?;
@@ -349,7 +351,7 @@ impl ast::Condition {
 }
 
 impl ast::ForIn {
-    fn check(&mut self, ctx: &mut CheckContext) -> Result<(), CheckError> {
+    fn check(&mut self, ctx: &mut CheckContext) -> Result<StatementResult, CheckError> {
         let value_result = self.value.check(ctx)?;
         if !value_result.is_local {
             return Err(CheckError::ExpectedLocalValue(self.location));

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -106,6 +106,7 @@ impl ast::File {
         // make sure any unforced values are now forced, to surface any problems
         // hidden by the fact that the values were unused
         store.evaluate_all(&mut exec)?;
+        scoped_store.evaluate_all(&mut exec)?;
 
         Ok(())
     }

--- a/src/execution/lazy/store.rs
+++ b/src/execution/lazy/store.rs
@@ -85,7 +85,8 @@ impl LazyStore {
 
     pub(super) fn evaluate_all(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
         for variable in &self.elements {
-            variable.force(exec)?;
+            let debug_info = variable.debug_info.clone();
+            variable.force(exec).with_context(|| debug_info.0.into())?;
         }
         Ok(())
     }
@@ -161,12 +162,10 @@ impl LazyScopedVariables {
                     match map.insert(node, value.clone()) {
                         Some(_) => {
                             return Err(ExecutionError::DuplicateVariable(format!(
-                                "{}.{} set at {} and {}",
-                                node,
-                                name,
-                                prev_debug_info.unwrap(),
-                                debug_info,
-                            )));
+                                "{}.{}",
+                                node, name,
+                            )))
+                            .with_context(|| (prev_debug_info.unwrap().0, debug_info.0).into());
                         }
                         _ => {}
                     };

--- a/src/execution/lazy/store.rs
+++ b/src/execution/lazy/store.rs
@@ -82,6 +82,13 @@ impl LazyStore {
         let value = variable.force(exec).with_context(|| debug_info.0.into())?;
         Ok(value)
     }
+
+    pub(super) fn evaluate_all(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
+        for variable in &self.elements {
+            variable.force(exec)?;
+        }
+        Ok(())
+    }
 }
 
 /// Data structure to hold scoped variables with lazy keys and values

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -197,6 +197,9 @@
 //! example stanza, whose query is `(identifier) @id`, `@id` would refer to the `identifier` syntax
 //! node that the stanza matched against.
 //!
+//! Unused query captures are considered errors, unless they start with an underscode. For example,
+//! a capture `@id` must be used within the stanza, but `@_id` does not.
+//!
 //! # Variables
 //!
 //! You can use variables to pass information between different stanzas and statements in a graph

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -92,7 +92,7 @@ fn can_scan_strings() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var new_node = #null
             var current_node = (node)
@@ -138,7 +138,7 @@ fn variables_in_scan_arms_are_local() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var current_node = (node)
 
@@ -257,7 +257,7 @@ fn can_use_global_variable() {
         indoc! {r#"
           global filename
 
-          (module) @root
+          (module)
           {
             node n
             attr (n) filename = filename
@@ -277,7 +277,7 @@ fn can_omit_global_variable_with_default() {
         indoc! {r#"
           global pkgname = ""
 
-          (module) @root
+          (module)
           {
             node n
             attr (n) pkgname = pkgname
@@ -320,7 +320,7 @@ fn can_use_variable_multiple_times() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             let x = (node)
             let y = x
@@ -338,7 +338,7 @@ fn can_nest_function_calls() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node node0
             attr (node0) val = (replace "accacc" (replace "abc" "b" "c") (replace "abc" "a" "b"))
@@ -356,7 +356,7 @@ fn cannot_use_nullable_regex() {
     fail_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             scan "abc" {
               "^\\b" {
@@ -450,7 +450,7 @@ fn can_execute_if_some() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             node node0
             if some @x {
@@ -472,7 +472,7 @@ fn can_execute_if_none() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x) @root
+          (module (import_statement)? @x)
           {
             node node0
             if none @x {
@@ -494,7 +494,7 @@ fn can_execute_if_some_and_none() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x (pass_statement)? @y) @root
+          (module (import_statement)? @x (pass_statement)? @y)
           {
             node node0
             if none @x, some @y {
@@ -516,7 +516,7 @@ fn can_execute_elif() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x (pass_statement)? @y) @root
+          (module (import_statement)? @x (pass_statement)? @y)
           {
             node node0
             if some @x {
@@ -538,7 +538,7 @@ fn can_execute_else() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x) @root
+          (module (import_statement)? @x)
           {
             node node0
             if some @x {
@@ -560,7 +560,7 @@ fn can_execute_if_literal() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x) @root
+          (module (import_statement)?)
           {
             node node0
             if #true {
@@ -582,7 +582,7 @@ fn skip_if_without_true_conditions() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x (import_statement)? @y) @root
+          (module (import_statement)? @x (import_statement)? @y)
           {
             node node0
             if some @x {
@@ -605,7 +605,7 @@ fn variables_are_local_in_if_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             let n = 1
             if some @x {
@@ -629,7 +629,7 @@ fn variables_do_not_escape_if_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             var n = 1
             if some @x {
@@ -653,7 +653,7 @@ fn variables_are_inherited_in_if_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             var n = 1
             if some @x {
@@ -679,7 +679,7 @@ fn can_execute_for_in_nonempty_list_capture() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             var n = 0
             for x in @xs {
@@ -703,7 +703,7 @@ fn can_execute_for_in_empty_list_capture() {
           pass
         "#,
         indoc! {r#"
-          (module (import_statement)* @xs) @root
+          (module (import_statement)* @xs)
           {
             var n = 0
             for x in @xs {
@@ -727,7 +727,7 @@ fn can_execute_for_in_list_literal() {
           pass
         "#,
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var n = 0
             for x in [#null, #null, #null] {
@@ -751,7 +751,7 @@ fn variables_are_local_in_for_in_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             let n = 1
             for x in @xs {
@@ -775,7 +775,7 @@ fn variables_do_not_escape_for_in_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             var n = 1
             for x in @xs {
@@ -801,7 +801,7 @@ fn variables_are_inherited_in_for_in_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)+ @xs) @root
+          (module (pass_statement)+ @xs)
           {
             var n = 0
             for x in @xs {
@@ -827,7 +827,7 @@ fn can_execute_list_comprehension() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             node node0
             attr (node0) val = [ (named-child-index x) for x in @xs ]
@@ -849,7 +849,7 @@ fn can_execute_set_comprehension() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             node node0
             attr (node0) val = { (source-text x) for x in @xs }

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -60,7 +60,7 @@ fn can_eq_equal_bools() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) eq = (eq #true #true)
@@ -78,7 +78,7 @@ fn can_eq_nonequal_bools() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) eq = (eq #true #false)
@@ -96,7 +96,7 @@ fn cannot_eq_bool_and_string() {
     fail_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) eq = (eq #true "false")
@@ -110,7 +110,7 @@ fn can_format_string_null_and_escaped_braces() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) str = (format "{} : {{ {} }}" "foo" #null)
@@ -128,7 +128,7 @@ fn cannot_format_with_missing_parameter() {
     fail_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) str = (format "{} : {{ {} }}" "foo")
@@ -142,7 +142,7 @@ fn cannot_format_with_extra_parameter() {
     fail_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) str = (format "{} : {{ {} }}" "foo" #null 42)
@@ -156,7 +156,7 @@ fn cannot_format_with_unexpected_opening_brace() {
     fail_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) str = (format "{} : { {} }}" "foo" #null)
@@ -170,7 +170,7 @@ fn cannot_format_with_unexpected_closing_brace() {
     fail_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) str = (format "{} : {{ {} }" "foo" #null)
@@ -184,7 +184,7 @@ fn can_concat_lists() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) xs = (concat [1, 2] [] [3, 4, 5])
@@ -202,7 +202,7 @@ fn can_join_list_with_separator() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) str = (join [1, 2, 3] ".")
@@ -220,7 +220,7 @@ fn can_join_list_without_separator() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
             attr (n) str = (join [1, 2, 3])

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -91,7 +91,7 @@ fn can_scan_strings() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var new_node = #null
             var current_node = (node)
@@ -137,7 +137,7 @@ fn variables_in_scan_arms_are_local() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var current_node = (node)
 
@@ -258,7 +258,7 @@ fn can_use_global_variable() {
         indoc! {r#"
           global filename
 
-          (module) @root
+          (module)
           {
             node n
             attr (n) filename = filename
@@ -278,7 +278,7 @@ fn can_omit_global_variable_with_default() {
         indoc! {r#"
           global pkgname = ""
 
-          (module) @root
+          (module)
           {
             node n
             attr (n) pkgname = pkgname
@@ -311,7 +311,7 @@ fn can_use_variable_multiple_times() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             let x = (node)
             let y = x
@@ -334,7 +334,7 @@ fn can_nest_function_calls() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node node0
             attr (node0) val = (replace "accacc" (replace "abc" "b" "c") (replace "abc" "a" "b"))
@@ -352,7 +352,7 @@ fn cannot_use_nullable_regex() {
     fail_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             scan "abc" {
               "^\\b" {
@@ -446,7 +446,7 @@ fn can_execute_if_some() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             node node0
             if some @x {
@@ -468,7 +468,7 @@ fn can_execute_if_none() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x) @root
+          (module (import_statement)? @x)
           {
             node node0
             if none @x {
@@ -490,7 +490,7 @@ fn can_execute_if_some_and_none() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x (pass_statement)? @y) @root
+          (module (import_statement)? @x (pass_statement)? @y)
           {
             node node0
             if none @x, some @y {
@@ -512,7 +512,7 @@ fn can_execute_elif() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x (pass_statement)? @y) @root
+          (module (import_statement)? @x (pass_statement)? @y)
           {
             node node0
             if some @x {
@@ -534,7 +534,7 @@ fn can_execute_else() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x) @root
+          (module (import_statement)? @x)
           {
             node node0
             if some @x {
@@ -556,7 +556,7 @@ fn can_execute_if_literal() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x) @root
+          (module (import_statement)?)
           {
             node node0
             if #true {
@@ -578,7 +578,7 @@ fn skip_if_without_true_conditions() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module (import_statement)? @x (import_statement)? @y) @root
+          (module (import_statement)? @x (import_statement)? @y)
           {
             node node0
             if some @x {
@@ -601,7 +601,7 @@ fn variables_are_local_in_if_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             let n = 1
             if some @x {
@@ -625,7 +625,7 @@ fn variables_do_not_escape_if_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             var n = 1
             if some @x {
@@ -649,7 +649,7 @@ fn variables_are_inherited_in_if_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)? @x) @root
+          (module (pass_statement)? @x)
           {
             var n = 1
             if some @x {
@@ -675,7 +675,7 @@ fn can_execute_for_in_nonempty_list_capture() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             var n = 0
             for x in @xs {
@@ -699,7 +699,7 @@ fn can_execute_for_in_empty_list_capture() {
           pass
         "#,
         indoc! {r#"
-          (module (import_statement)* @xs) @root
+          (module (import_statement)* @xs)
           {
             var n = 0
             for x in @xs {
@@ -723,7 +723,7 @@ fn can_execute_for_in_list_literal() {
           pass
         "#,
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var n = 0
             for x in [#null, #null, #null] {
@@ -747,7 +747,7 @@ fn variables_are_local_in_for_in_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             let n = 1
             for x in @xs {
@@ -771,7 +771,7 @@ fn variables_do_not_escape_for_in_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             var n = 1
             for x in @xs {
@@ -797,7 +797,7 @@ fn variables_are_inherited_in_for_in_body() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)+ @xs) @root
+          (module (pass_statement)+ @xs)
           {
             var n = 0
             for x in @xs {
@@ -823,7 +823,7 @@ fn can_execute_list_comprehension() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             node node0
             attr (node0) val = [ (named-child-index x) for x in @xs ]
@@ -845,7 +845,7 @@ fn can_execute_set_comprehension() {
           pass
         "#,
         indoc! {r#"
-          (module (pass_statement)* @xs) @root
+          (module (pass_statement)* @xs)
           {
             node node0
             attr (node0) val = { (source-text x) for x in @xs }
@@ -916,7 +916,7 @@ fn can_build_node() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node node0
           }
@@ -951,7 +951,7 @@ fn can_build_edge() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node node0
             node node1
@@ -971,7 +971,7 @@ fn can_build_edges() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node node0
             node node1
@@ -997,7 +997,7 @@ fn can_set_mutable_local_variables() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var node = #null
 
@@ -1063,7 +1063,7 @@ fn variables_can_be_scoped_in_arbitrary_expressions() {
           print(a.d.f)
         "#},
         indoc! {r#"
-          (call function:(_)@fun arguments: (argument_list (_)@arg)) {
+          (call function:(_) arguments: (argument_list (_)@arg)) {
           ; let @arg.no_object.lala = 3 ; error
             let @arg.object.lala = 3
             let @arg.object.object.lala = 12
@@ -1083,7 +1083,7 @@ fn can_mutate_inside_scan_no_branch_simple() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
 
@@ -1110,7 +1110,7 @@ fn can_mutate_inside_scan_once_first_branch_simple() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
 
@@ -1137,7 +1137,7 @@ fn can_mutate_inside_scan_once_first_branch() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
 
@@ -1177,7 +1177,7 @@ fn can_mutate_inside_scan_once_second_branch() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
 
@@ -1217,7 +1217,7 @@ fn can_mutate_inside_scan_once_no_branch() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             node n
 
@@ -1256,7 +1256,7 @@ fn can_mutate_inside_scan_multiple_times_simple() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var x = 0
             var y = 0
@@ -1286,7 +1286,7 @@ fn can_mutate_inside_scan_multiple_times() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var x = 0
             var y = 0
@@ -1322,7 +1322,7 @@ fn can_mutate_inside_nested_scan_multiple_times_simple() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var x = 0
 
@@ -1353,7 +1353,7 @@ fn can_mutate_inside_nested_scan_multiple_times() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var x = 0
             var y = 0
@@ -1394,7 +1394,7 @@ fn variable_let_executed_once() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             let x = (node)
             attr ((node)) ref = x
@@ -1416,7 +1416,7 @@ fn variable_set_executed_once() {
     check_execution(
         "pass",
         indoc! {r#"
-          (module) @root
+          (module)
           {
             var x = #null
             set x = (node)

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -16,7 +16,7 @@ use tree_sitter_graph::ParseError;
 fn can_parse_blocks() {
     let source = r#"
         (function_definition
-          name: (identifier) @cap1) @cap2
+          name: (identifier) @_cap1) @cap2
         {
           node loc1
           node @cap2.prop1
@@ -1079,7 +1079,7 @@ fn cannot_parse_scan_of_nonlocal_variable() {
 #[test]
 fn can_parse_list_comprehension() {
     let source = r#"
-        (module (_)* @xs)@mod
+        (module (_)* @xs)
         {
           print [ (named-child-index x) for x in @xs ]
         }
@@ -1132,7 +1132,7 @@ fn can_parse_list_comprehension() {
 #[test]
 fn can_parse_set_comprehension() {
     let source = r#"
-        (module (_)* @xs)@mod
+        (module (_)* @xs)
         {
           print { (named-child-index x) for x in @xs }
         }
@@ -1578,4 +1578,24 @@ fn multiline_query_parse_errors_have_file_location() {
     assert_eq!(err.row, 6, "expected row 6, got {}", err.row);
     assert_eq!(err.column, 13, "expected column 13, got {}", err.column);
     assert_eq!(err.offset, 112, "expected offset 112, got {}", err.offset);
+}
+
+#[test]
+fn cannot_parse_unused_capture() {
+    let source = r#"
+        (function_definition name: (identifier) @name) {
+        }
+    "#;
+    if let Ok(_) = File::from_str(tree_sitter_python::language(), source) {
+        panic!("Parse succeeded unexpectedly");
+    }
+}
+
+#[test]
+fn can_parse_explicitly_unused_capture() {
+    let source = r#"
+        (function_definition name: (identifier) @_name) {
+        }
+    "#;
+    File::from_str(tree_sitter_python::language(), source).expect("parse to succeed");
 }


### PR DESCRIPTION
This PR addresses some of the issues that contributed to github/stack-graphs#266.

- Unused captures in patterns are now considered errors, unless their name is prefixed with an undersoce. This should help prevent accidental errors resulting from using the wrong variables, or just mistyping them. Perhaps in the future we can introduce a way to surface warnings, and use those. However, that change would be more invasive, so I want to try this first and get some feedback on its usefulness.

- Lazy evaluation caused some errors to be unreported unless the variables involved in the problematic code were actually used. We use lazy evaluation not as an optimization, but to provide flexible evaluation order. Therefore, it is more useful and more predictable to users if all errors are reported. Therefore, we ensure all lazy values are forced during execution.

- Errors about duplicate scoped variables did not get proper context attached to them, such that the error reported the statement that forced the values, not the statements involved in creating them. We now set the proper context, and also report both statements with nice source fragments in these cases.

_This also bumps the version so we can do a release to use this in github/stack-graphs._

## Example

This is the new output for the duplicate scoped variables error:

![image](https://github.com/tree-sitter/tree-sitter-graph/assets/999073/6618f836-fee0-45f4-a64b-7f1294984ef8)
