### PR TITLE
Expose method to execute TSG matches without executing stanzas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.1 -- 2023-05-15
+
+### Library
+
+#### Added
+
+- The `ast::File::try_visit_matches` method can be used to execute the stanza query matching without executing the stanza bodies.
+
 ## v0.10.0 -- 2023-05-10
 
 ### DSL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.10.0"
+version = "0.10.1"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -14,6 +14,7 @@ use tree_sitter::CaptureQuantifier;
 use tree_sitter::Language;
 use tree_sitter::Query;
 
+use crate::parser::Range;
 use crate::Identifier;
 use crate::Location;
 
@@ -66,7 +67,7 @@ pub struct Stanza {
     pub full_match_stanza_capture_index: usize,
     /// Capture index of the full match in the file query
     pub full_match_file_capture_index: usize,
-    pub location: Location,
+    pub range: Range,
 }
 
 /// A statement that can appear in a graph DSL stanza

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -198,7 +198,7 @@ impl ast::Stanza {
         if !unused_captures.is_empty() {
             return Err(CheckError::UnusedCaptures(
                 unused_captures.join(" "),
-                self.location,
+                self.range.start,
             ));
         }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -12,6 +12,7 @@ use tree_sitter::QueryMatch;
 use tree_sitter::Tree;
 
 use crate::ast::File;
+use crate::ast::Stanza;
 use crate::execution::error::ExecutionError;
 use crate::functions::Functions;
 use crate::graph::Graph;
@@ -93,6 +94,23 @@ impl File {
         }
 
         Ok(())
+    }
+
+    pub fn try_visit_matches<'a, 'tree, E, F>(
+        &self,
+        tree: &'tree Tree,
+        source: &'tree str,
+        lazy: bool,
+        visit: F,
+    ) -> Result<(), E>
+    where
+        F: FnMut(&Stanza, QueryMatch<'_, 'tree>) -> Result<(), E>,
+    {
+        if lazy {
+            self.try_visit_matches_lazy(tree, source, visit)
+        } else {
+            self.try_visit_matches_strict(tree, source, visit)
+        }
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -118,7 +118,8 @@ impl File {
                         let index = file_query
                             .capture_index_for_name(name)
                             .expect("missing index for capture");
-                        let quantifier = file_query.capture_quantifiers(0)[index as usize];
+                        let quantifier =
+                            file_query.capture_quantifiers(mat.pattern_index)[index as usize];
                         (name, quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_file_capture_index as u32)

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -126,7 +126,7 @@ impl File {
                     mat,
                     full_capture_index: stanza.full_match_file_capture_index as u32,
                     named_captures,
-                    query_location: stanza.location,
+                    query_location: stanza.range.start,
                 })
             })
         } else {
@@ -148,7 +148,7 @@ impl File {
                     mat,
                     full_capture_index: stanza.full_match_stanza_capture_index as u32,
                     named_captures,
-                    query_location: stanza.location,
+                    query_location: stanza.range.start,
                 })
             })
         }
@@ -183,7 +183,7 @@ impl Stanza {
                 mat,
                 full_capture_index: self.full_match_stanza_capture_index as u32,
                 named_captures,
-                query_location: self.location,
+                query_location: self.range.start,
             })
         })
     }

--- a/src/execution/error.rs
+++ b/src/execution/error.rs
@@ -95,7 +95,7 @@ impl StatementContext {
         Self {
             statement: format!("{}", stmt),
             statement_location: stmt.location(),
-            stanza_location: stanza.location,
+            stanza_location: stanza.range.start,
             source_location: Location::from(source_node.range().start_point),
             node_kind: source_node.kind().to_string(),
         }

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -187,12 +187,10 @@ impl ast::Stanza {
         trace!("{{");
         for statement in &self.statements {
             let error_context = {
-                let node = mat
-                    .captures
-                    .iter()
-                    .find(|c| c.index as usize == self.full_match_file_capture_index)
-                    .expect("missing capture for full match")
-                    .node;
+                let node = self
+                    .full_capture_from_file_match(mat)
+                    .next()
+                    .expect("missing capture for full match");
                 StatementContext::new(&statement, &self, &node)
             };
             let mut exec = ExecutionContext {

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -22,11 +22,11 @@ use crate::ast;
 use crate::execution::error::ExecutionError;
 use crate::execution::error::ResultWithExecutionError;
 use crate::execution::error::StatementContext;
-use crate::execution::query_capture_value;
 use crate::execution::ExecutionConfig;
 use crate::functions::Functions;
 use crate::graph;
 use crate::graph::Graph;
+use crate::graph::Value;
 use crate::variables::Globals;
 use crate::variables::MutVariables;
 use crate::variables::VariableMap;
@@ -167,7 +167,7 @@ impl ast::Stanza {
     ) -> Result<(), ExecutionError> {
         let current_regex_captures = vec![];
         locals.clear();
-        let node = query_capture_value(self.full_match_file_capture_index, One, &mat, graph);
+        let node = Value::from_nodes(graph, self.full_capture_from_file_match(mat), One);
         debug!("match {} at {}", node, self.location);
         trace!("{{");
         for statement in &self.statements {
@@ -613,11 +613,11 @@ impl ast::SetComprehension {
 
 impl ast::Capture {
     fn evaluate_lazy(&self, exec: &mut ExecutionContext) -> Result<LazyValue, ExecutionError> {
-        Ok(query_capture_value(
-            self.file_capture_index,
-            self.quantifier,
-            exec.mat,
+        Ok(Value::from_nodes(
             exec.graph,
+            exec.mat
+                .nodes_for_capture_index(self.file_capture_index as u32),
+            self.quantifier,
         )
         .into())
     }

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -185,7 +185,7 @@ impl ast::Stanza {
             .nodes_for_capture_index(self.full_match_file_capture_index as u32)
             .next()
             .expect("missing capture for full match");
-        debug!("match {:?} at {}", node, self.location);
+        debug!("match {:?} at {}", node, self.range.start);
         trace!("{{");
         for statement in &self.statements {
             let error_context = { StatementContext::new(&statement, &self, &node) };

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -44,7 +44,7 @@ use crate::ast::UnscopedVariable;
 use crate::ast::Variable;
 use crate::execution::error::ExecutionError;
 use crate::execution::error::ResultWithExecutionError;
-use crate::execution::query_capture_value;
+use crate::execution::error::StatementContext;
 use crate::execution::CancellationFlag;
 use crate::execution::ExecutionConfig;
 use crate::graph::Attributes;
@@ -57,8 +57,6 @@ use crate::variables::VariableMap;
 use crate::variables::Variables;
 use crate::Identifier;
 use crate::Location;
-
-use super::error::StatementContext;
 
 impl File {
     /// Executes this graph DSL file against a source file, saving the results into an existing
@@ -600,12 +598,13 @@ impl SetComprehension {
 
 impl Capture {
     fn evaluate(&self, exec: &mut ExecutionContext) -> Result<Value, ExecutionError> {
-        Ok(query_capture_value(
-            self.stanza_capture_index,
-            self.quantifier,
-            exec.mat,
+        Ok(Value::from_nodes(
             exec.graph,
-        ))
+            exec.mat
+                .nodes_for_capture_index(self.stanza_capture_index as u32),
+            self.quantifier,
+        )
+        .into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub use execution::error::ExecutionError;
 pub use execution::CancellationError;
 pub use execution::CancellationFlag;
 pub use execution::ExecutionConfig;
+pub use execution::Match;
 pub use execution::NoCancellation;
 pub use parser::Location;
 pub use parser::ParseError;


### PR DESCRIPTION
This PR exposes a method to match stanza queries without also executing stanza bodies. This has essentially the same effect as running `tree-sitter query` on a query file containing all stanza queries. This will be used in github/stack-graphs to implement a command to emulate `tree-sitter query`.
