### PR TITLE
Include edge statement locations in debug information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.2 -- 2023-05-25
+
+### Library
+
+#### Added
+
+- Edge debug information now contains the TSG location of the `edge` statement if `ExecutionConfig::location_attr` is set.
+
+#### Changed
+
+- The TSG location in the debug information is formatted more explicitly as `line XX column YY` instead of `(XX, YY)`.
+
 ## v0.10.1 -- 2023-05-15
 
 ### Library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.10.1"
+version = "0.10.2"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -348,7 +348,14 @@ impl CreateEdge {
     ) -> Result<(), ExecutionError> {
         if let Some(location_attr) = &config.location_attr {
             attributes
-                .add(location_attr.clone(), format!("{}", self.location))
+                .add(
+                    location_attr.clone(),
+                    format!(
+                        "line {} column {}",
+                        self.location.row + 1,
+                        self.location.column + 1
+                    ),
+                )
                 .map_err(|_| ExecutionError::DuplicateAttribute(location_attr.as_str().into()))?;
         }
         Ok(())
@@ -373,7 +380,10 @@ impl Variable {
                 Variable::Unscoped(v) => v.location,
             };
             attributes
-                .add(location_attr.clone(), format!("{}", location))
+                .add(
+                    location_attr.clone(),
+                    format!("line {} column {}", location.row + 1, location.column + 1),
+                )
                 .map_err(|_| ExecutionError::DuplicateAttribute(location_attr.as_str().into()))?;
         }
         Ok(())

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -24,6 +24,7 @@ use crate::execution::error::StatementContext;
 use crate::execution::ExecutionConfig;
 use crate::functions::Functions;
 use crate::graph;
+use crate::graph::Attributes;
 use crate::graph::Graph;
 use crate::graph::Value;
 use crate::variables::Globals;
@@ -282,7 +283,9 @@ impl ast::CreateEdge {
     fn execute_lazy(&self, exec: &mut ExecutionContext) -> Result<(), ExecutionError> {
         let source = self.source.evaluate_lazy(exec)?;
         let sink = self.sink.evaluate_lazy(exec)?;
-        let stmt = LazyCreateEdge::new(source, sink, exec.error_context.clone().into());
+        let mut attributes = Attributes::new();
+        self.add_debug_attrs(&mut attributes, exec.config)?;
+        let stmt = LazyCreateEdge::new(source, sink, attributes, exec.error_context.clone().into());
         exec.lazy_graph.push(stmt.into());
         Ok(())
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -260,6 +260,7 @@ impl Edge {
 }
 
 /// A set of attributes associated with a graph node or edge
+#[derive(Clone, Debug)]
 pub struct Attributes {
     values: HashMap<Identifier, Value>,
 }


### PR DESCRIPTION
This PR adds support to record the TSG locations of `edge` statements in edge debug information.

Additonally, it updates the formatting of TSG locations to `line XX column YY`, which is a bit more obvious than the previous `(XX, YY)`.

The patch version is bumped so this can be released.
