### PR TITLE
Inherited scoped variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.10.3 -- 2023-06-02
+## v0.10.3 -- 2023-06-01
 
 ### DSL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.3 -- 2023-06-02
+
+### DSL
+
+#### Added
+
+- Scoped variables can be inherited by child nodes by specifying `inherit .var_name` as part of the source. Using `@node.var_name` will either use the value set on the node itself, or otherwise the one set on the closest enclosing node.
+
 ## v0.10.2 -- 2023-05-25
 
 ### Library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.10.2"
+version = "0.10.3"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,6 +9,7 @@
 
 use regex::Regex;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt;
 use tree_sitter::CaptureQuantifier;
 use tree_sitter::Language;
@@ -24,6 +25,8 @@ pub struct File {
     pub language: Language,
     /// The expected global variables used in this file
     pub globals: Vec<Global>,
+    /// The scoped variables that are inherited by child nodes
+    pub inherited_variables: HashSet<Identifier>,
     /// The combined query of all stanzas in the file
     pub query: Option<Query>,
     /// The list of stanzas in the file
@@ -37,6 +40,7 @@ impl File {
         File {
             language,
             globals: Vec::new(),
+            inherited_variables: HashSet::new(),
             query: None,
             stanzas: Vec::new(),
             shorthands: AttributeShorthands::new(),

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -12,6 +12,7 @@ mod values;
 use log::{debug, trace};
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use tree_sitter::QueryCursor;
 use tree_sitter::QueryMatch;
@@ -81,6 +82,7 @@ impl ast::File {
                 &mut lazy_graph,
                 &mut function_parameters,
                 &mut prev_element_debug_info,
+                &self.inherited_variables,
                 &self.shorthands,
                 cancellation_flag,
             )
@@ -92,6 +94,7 @@ impl ast::File {
             functions: config.functions,
             store: &store,
             scoped_store: &scoped_store,
+            inherited_variables: &self.inherited_variables,
             function_parameters: &mut function_parameters,
             prev_element_debug_info: &mut prev_element_debug_info,
             cancellation_flag,
@@ -141,6 +144,7 @@ struct ExecutionContext<'a, 'c, 'g, 'tree> {
     function_parameters: &'a mut Vec<graph::Value>, // re-usable buffer to reduce memory allocations
     prev_element_debug_info: &'a mut HashMap<GraphElementKey, DebugInfo>,
     error_context: StatementContext,
+    inherited_variables: &'a HashSet<Identifier>,
     shorthands: &'a ast::AttributeShorthands,
     cancellation_flag: &'a dyn CancellationFlag,
 }
@@ -152,6 +156,7 @@ pub(self) struct EvaluationContext<'a, 'tree> {
     pub functions: &'a Functions,
     pub store: &'a LazyStore,
     pub scoped_store: &'a LazyScopedVariables,
+    pub inherited_variables: &'a HashSet<Identifier>,
     pub function_parameters: &'a mut Vec<graph::Value>, // re-usable buffer to reduce memory allocations
     pub prev_element_debug_info: &'a mut HashMap<GraphElementKey, DebugInfo>,
     pub cancellation_flag: &'a dyn CancellationFlag,
@@ -177,6 +182,7 @@ impl ast::Stanza {
         lazy_graph: &mut Vec<LazyStatement>,
         function_parameters: &mut Vec<graph::Value>,
         prev_element_debug_info: &mut HashMap<GraphElementKey, DebugInfo>,
+        inherited_variables: &HashSet<Identifier>,
         shorthands: &ast::AttributeShorthands,
         cancellation_flag: &dyn CancellationFlag,
     ) -> Result<(), ExecutionError> {
@@ -203,6 +209,7 @@ impl ast::Stanza {
                 function_parameters,
                 prev_element_debug_info,
                 error_context,
+                inherited_variables,
                 shorthands,
                 cancellation_flag,
             };
@@ -366,6 +373,7 @@ impl ast::Scan {
                 function_parameters: exec.function_parameters,
                 prev_element_debug_info: exec.prev_element_debug_info,
                 error_context: exec.error_context.clone(),
+                inherited_variables: exec.inherited_variables,
                 shorthands: exec.shorthands,
                 cancellation_flag: exec.cancellation_flag,
             };
@@ -431,6 +439,7 @@ impl ast::If {
                     function_parameters: exec.function_parameters,
                     prev_element_debug_info: exec.prev_element_debug_info,
                     error_context: exec.error_context.clone(),
+                    inherited_variables: exec.inherited_variables,
                     shorthands: exec.shorthands,
                     cancellation_flag: exec.cancellation_flag,
                 };
@@ -477,6 +486,7 @@ impl ast::ForIn {
                 function_parameters: exec.function_parameters,
                 prev_element_debug_info: exec.prev_element_debug_info,
                 error_context: exec.error_context.clone(),
+                inherited_variables: exec.inherited_variables,
                 shorthands: exec.shorthands,
                 cancellation_flag: exec.cancellation_flag,
             };
@@ -520,6 +530,7 @@ impl ast::Expression {
             functions: exec.config.functions,
             store: exec.store,
             scoped_store: exec.scoped_store,
+            inherited_variables: exec.inherited_variables,
             function_parameters: exec.function_parameters,
             prev_element_debug_info: exec.prev_element_debug_info,
             cancellation_flag: exec.cancellation_flag,
@@ -569,6 +580,7 @@ impl ast::ListComprehension {
                 function_parameters: exec.function_parameters,
                 prev_element_debug_info: exec.prev_element_debug_info,
                 error_context: exec.error_context.clone(),
+                inherited_variables: exec.inherited_variables,
                 shorthands: exec.shorthands,
                 cancellation_flag: exec.cancellation_flag,
             };
@@ -611,6 +623,7 @@ impl ast::SetComprehension {
                 function_parameters: exec.function_parameters,
                 prev_element_debug_info: exec.prev_element_debug_info,
                 error_context: exec.error_context.clone(),
+                inherited_variables: exec.inherited_variables,
                 shorthands: exec.shorthands,
                 cancellation_flag: exec.cancellation_flag,
             };
@@ -825,6 +838,7 @@ impl ast::AttributeShorthand {
             function_parameters: exec.function_parameters,
             prev_element_debug_info: exec.prev_element_debug_info,
             error_context: exec.error_context.clone(),
+            inherited_variables: exec.inherited_variables,
             shorthands: exec.shorthands,
             cancellation_flag: exec.cancellation_flag,
         };

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -36,11 +36,11 @@ use crate::Location;
 /// that they don't outlive the tree-sitter syntax tree that they are generated from.
 #[derive(Default)]
 pub struct Graph<'tree> {
-    syntax_nodes: HashMap<SyntaxNodeID, Node<'tree>>,
+    pub(crate) syntax_nodes: HashMap<SyntaxNodeID, Node<'tree>>,
     graph_nodes: Vec<GraphNode>,
 }
 
-type SyntaxNodeID = u32;
+pub(crate) type SyntaxNodeID = u32;
 type GraphNodeID = u32;
 
 impl<'tree> Graph<'tree> {
@@ -635,7 +635,7 @@ impl Serialize for Value {
 /// A reference to a syntax node in a graph
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct SyntaxNodeRef {
-    index: SyntaxNodeID,
+    pub(crate) index: SyntaxNodeID,
     kind: &'static str,
     position: tree_sitter::Point,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -291,14 +291,19 @@ impl<'a> Parser<'a> {
     fn parse_into_file(&mut self, file: &mut ast::File) -> Result<(), ParseError> {
         self.consume_whitespace();
         while self.try_peek().is_some() {
-            if let Ok(_) = self.consume_token("global") {
-                self.consume_whitespace();
-                let global = self.parse_global()?;
-                file.globals.push(global);
-            } else if let Ok(_) = self.consume_token("attribute") {
+            if let Ok(_) = self.consume_token("attribute") {
                 self.consume_whitespace();
                 let shorthand = self.parse_shorthand()?;
                 file.shorthands.add(shorthand);
+            } else if let Ok(_) = self.consume_token("global") {
+                self.consume_whitespace();
+                let global = self.parse_global()?;
+                file.globals.push(global);
+            } else if let Ok(_) = self.consume_token("inherit") {
+                self.consume_whitespace();
+                self.consume_token(".")?;
+                let name = self.parse_identifier("inherit")?;
+                file.inherited_variables.insert(name);
             } else {
                 let stanza = self.parse_stanza(file.language)?;
                 file.stanzas.push(stanza);

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -936,3 +936,75 @@ fn can_execute_shorthand() {
         "#},
     );
 }
+
+#[test]
+fn can_access_inherited_attribute() {
+    check_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            inherit .test
+            (function_definition)@def {
+              node @def.test
+              attr (@def.test) in_def
+            }
+            (pass_statement)@pass {
+              attr (@pass.test) in_pass
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            in_def: #true
+            in_pass: #true
+        "#},
+    );
+}
+
+#[test]
+fn can_overwrite_inherited_attribute() {
+    check_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            inherit .test
+            (function_definition)@def {
+              node @def.test
+              attr (@def.test) in_def
+            }
+            (pass_statement)@pass {
+              node @pass.test
+            }
+            (pass_statement)@pass {
+              attr (@pass.test) in_pass
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            in_def: #true
+          node 1
+            in_pass: #true
+        "#},
+    );
+}
+
+#[test]
+fn cannot_access_non_inherited_variable() {
+    fail_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            (function_definition)@def {
+              node @def.test
+            }
+            (pass_statement)@pass {
+              attr (@pass.test) in_pass
+            }
+        "#},
+    );
+}

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -1455,3 +1455,75 @@ fn can_execute_shorthand() {
         "#},
     );
 }
+
+#[test]
+fn can_access_inherited_attribute() {
+    check_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            inherit .test
+            (function_definition)@def {
+              node @def.test
+              attr (@def.test) in_def
+            }
+            (pass_statement)@pass {
+              attr (@pass.test) in_pass
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            in_def: #true
+            in_pass: #true
+        "#},
+    );
+}
+
+#[test]
+fn can_overwrite_inherited_attribute() {
+    check_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            inherit .test
+            (function_definition)@def {
+              node @def.test
+              attr (@def.test) in_def
+            }
+            (pass_statement)@pass {
+              node @pass.test
+            }
+            (pass_statement)@pass {
+              attr (@pass.test) in_pass
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            in_def: #true
+          node 1
+            in_pass: #true
+        "#},
+    );
+}
+
+#[test]
+fn cannot_access_non_inherited_variable() {
+    fail_execution(
+        indoc! { r#"
+          def get_f():
+            pass
+        "#},
+        indoc! {r#"
+            (function_definition)@def {
+              node @def.test
+            }
+            (pass_statement)@pass {
+              attr (@pass.test) in_pass
+            }
+        "#},
+    );
+}

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -1599,3 +1599,12 @@ fn can_parse_explicitly_unused_capture() {
     "#;
     File::from_str(tree_sitter_python::language(), source).expect("parse to succeed");
 }
+
+#[test]
+fn can_parse_inherit_directives() {
+    let source = r#"
+        inherit .scope
+    "#;
+    let file = File::from_str(tree_sitter_python::language(), source).expect("parse to succeed");
+    assert!(file.inherited_variables.contains("scope".into()));
+}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 -- 2023-06-01
+
+### Added
+
+- Add new `inherit` keyword
+
 ## 0.1.0 -- 2022-05-11
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tree-sitter-graph",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "tree-sitter",
     "engines": {
         "vscode": "^1.60.0"

--- a/vscode/syntaxes/tree-sitter-graph.tmLanguage.json
+++ b/vscode/syntaxes/tree-sitter-graph.tmLanguage.json
@@ -16,7 +16,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.tsg",
-				"match": "^\\s*(attr|attribute|edge|for|global|if|let|node|none|print|scan|set|some|var)\\b"
+				"match": "^\\s*(attr|attribute|edge|for|global|if|inherit|let|node|none|print|scan|set|some|var)\\b"
 			}]
 		},
 		"functions": {


### PR DESCRIPTION
This PR adds support for inherited scoped variables. Until now, scoped variables were attached to a single node. With this PR it is possible to add `inherit .var_name` to a file, which will cause `@node.var_name` to look for the scoped variable or on the node or any of its parents (selecting the closest parent that has a value for that variable).

This adds an easy mechanism to propagate information from parent to child nodes without having to write a lot of verbose code to do it.

Fixes #88.
