### PR TITLE
Error improvements and small bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.4 -- 2023-06-02
+
+### Library
+
+#### Added
+
+- Several errors include more context in the error message: Duplicate errors report both statements using source snippets. Edge statements report which argument (the source or the sink) triggered an evluation error.
+
+#### Fixed
+
+- Ensure that edge attribute statements are executed after edges are created, to prevent non-deterministic ordering bugs in lazy execution mode.
+
 ## v0.10.3 -- 2023-06-01
 
 ### DSL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.10.3"
+version = "0.10.4"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -65,7 +65,7 @@ impl ast::File {
         let mut locals = VariableMap::new();
         let mut store = LazyStore::new();
         let mut scoped_store = LazyScopedVariables::new();
-        let mut lazy_graph = Vec::new();
+        let mut lazy_graph = LazyGraph::new();
         let mut function_parameters = Vec::new();
         let mut prev_element_debug_info = HashMap::new();
 
@@ -99,9 +99,7 @@ impl ast::File {
             prev_element_debug_info: &mut prev_element_debug_info,
             cancellation_flag,
         };
-        for graph_stmt in &lazy_graph {
-            graph_stmt.evaluate(&mut exec)?;
-        }
+        lazy_graph.evaluate(&mut exec)?;
         // make sure any unforced values are now forced, to surface any problems
         // hidden by the fact that the values were unused
         store.evaluate_all(&mut exec)?;
@@ -140,7 +138,7 @@ struct ExecutionContext<'a, 'c, 'g, 'tree> {
     mat: &'a QueryMatch<'a, 'tree>,
     store: &'a mut LazyStore,
     scoped_store: &'a mut LazyScopedVariables,
-    lazy_graph: &'a mut Vec<LazyStatement>,
+    lazy_graph: &'a mut LazyGraph,
     function_parameters: &'a mut Vec<graph::Value>, // re-usable buffer to reduce memory allocations
     prev_element_debug_info: &'a mut HashMap<GraphElementKey, DebugInfo>,
     error_context: StatementContext,
@@ -179,7 +177,7 @@ impl ast::Stanza {
         locals: &mut VariableMap<'l, LazyValue>,
         store: &mut LazyStore,
         scoped_store: &mut LazyScopedVariables,
-        lazy_graph: &mut Vec<LazyStatement>,
+        lazy_graph: &mut LazyGraph,
         function_parameters: &mut Vec<graph::Value>,
         prev_element_debug_info: &mut HashMap<GraphElementKey, DebugInfo>,
         inherited_variables: &HashSet<Identifier>,

--- a/src/execution/lazy/statements.rs
+++ b/src/execution/lazy/statements.rs
@@ -22,6 +22,46 @@ use super::values::*;
 use super::EvaluationContext;
 use super::GraphElementKey;
 
+/// Lazy graph
+#[derive(Debug)]
+pub(super) struct LazyGraph {
+    edge_statements: Vec<LazyStatement>,
+    attr_statements: Vec<LazyStatement>,
+    print_statements: Vec<LazyStatement>,
+}
+
+impl LazyGraph {
+    pub(super) fn new() -> Self {
+        LazyGraph {
+            edge_statements: Vec::new(),
+            attr_statements: Vec::new(),
+            print_statements: Vec::new(),
+        }
+    }
+
+    pub(super) fn push(&mut self, stmt: LazyStatement) {
+        match stmt {
+            LazyStatement::AddGraphNodeAttribute(_) => self.attr_statements.push(stmt),
+            LazyStatement::CreateEdge(_) => self.edge_statements.push(stmt),
+            LazyStatement::AddEdgeAttribute(_) => self.attr_statements.push(stmt),
+            LazyStatement::Print(_) => self.print_statements.push(stmt),
+        }
+    }
+
+    pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
+        for stmt in &self.edge_statements {
+            stmt.evaluate(exec)?;
+        }
+        for stmt in &self.attr_statements {
+            stmt.evaluate(exec)?;
+        }
+        for stmt in &self.print_statements {
+            stmt.evaluate(exec)?;
+        }
+        Ok(())
+    }
+}
+
 /// Lazy graph statements
 #[derive(Debug)]
 pub(super) enum LazyStatement {

--- a/src/execution/lazy/statements.rs
+++ b/src/execution/lazy/statements.rs
@@ -112,7 +112,10 @@ impl LazyAddGraphNodeAttribute {
     }
 
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
-        let node = self.node.evaluate_as_graph_node(exec)?;
+        let node = self
+            .node
+            .evaluate_as_graph_node(exec)
+            .with_context(|| "Evaluating target node".to_string().into())?;
         for attribute in &self.attributes {
             let value = attribute.value.evaluate(exec)?;
             let prev_debug_info = exec.prev_element_debug_info.insert(
@@ -175,8 +178,14 @@ impl LazyCreateEdge {
     }
 
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
-        let source = self.source.evaluate_as_graph_node(exec)?;
-        let sink = self.sink.evaluate_as_graph_node(exec)?;
+        let source = self
+            .source
+            .evaluate_as_graph_node(exec)
+            .with_context(|| "Evaluating edge source".to_string().into())?;
+        let sink = self
+            .sink
+            .evaluate_as_graph_node(exec)
+            .with_context(|| "Evaluating edge sink".to_string().into())?;
         let prev_debug_info = exec
             .prev_element_debug_info
             .insert(GraphElementKey::Edge(source, sink), self.debug_info.clone());
@@ -236,8 +245,14 @@ impl LazyAddEdgeAttribute {
     }
 
     pub(super) fn evaluate(&self, exec: &mut EvaluationContext) -> Result<(), ExecutionError> {
-        let source = self.source.evaluate_as_graph_node(exec)?;
-        let sink = self.sink.evaluate_as_graph_node(exec)?;
+        let source = self
+            .source
+            .evaluate_as_graph_node(exec)
+            .with_context(|| "Evaluating edge source".to_string().into())?;
+        let sink = self
+            .sink
+            .evaluate_as_graph_node(exec)
+            .with_context(|| "Evaluating edge sink".to_string().into())?;
         for attribute in &self.attributes {
             let value = attribute.value.evaluate(exec)?;
             let edge = match exec.graph[source].get_edge_mut(sink) {

--- a/src/execution/lazy/values.rs
+++ b/src/execution/lazy/values.rs
@@ -13,6 +13,7 @@ use std::convert::From;
 use std::fmt;
 
 use crate::execution::error::ExecutionError;
+use crate::execution::error::ResultWithExecutionError;
 use crate::graph::GraphNodeRef;
 use crate::graph::SyntaxNodeRef;
 use crate::graph::Value;
@@ -184,7 +185,11 @@ impl LazyScopedVariable {
     }
 
     fn resolve<'a>(&self, exec: &'a mut EvaluationContext) -> Result<LazyValue, ExecutionError> {
-        let scope = self.scope.as_ref().evaluate_as_syntax_node(exec)?;
+        let scope = self
+            .scope
+            .as_ref()
+            .evaluate_as_syntax_node(exec)
+            .with_context(|| format!("Evaluating scope of variable _.{}", self.name).into())?;
         let scoped_store = &exec.scoped_store;
         scoped_store.evaluate(&scope, &self.name, exec)
     }

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -116,10 +116,10 @@ fn can_scan_strings() {
         "#},
         indoc! {r#"
           node 0
-            name: "alpha"
-          edge 0 -> 2
+          edge 0 -> 1
           node 1
-          edge 1 -> 0
+            name: "alpha"
+          edge 1 -> 2
           node 2
             name: "beta"
           edge 2 -> 3


### PR DESCRIPTION

Several errors report more context for easier debugging.

An ordering bug in lazy evaluation mode was fixed which sometimes triggered when edge attribute statements were executed before the corresponding edge statement.

Bumps patch version to allow release.
