### PR TITLE
Attempt at fixing unwrap bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.10.5 -- 2023-06-26
+
+#### Fixed
+
+- A panic that sometimes occurred in lazy execution mode.
+
 ## v0.10.4 -- 2023-06-02
 
 ### Library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.10.4"
+version = "0.10.5"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"


### PR DESCRIPTION
Occasionally a panic happend in `store.rs` because a `None` value was unwrapped in `LazyScopedVariables::force`.

## What happens?

The code there builds two maps at the same time. When one map contains a previous value, so should the other. The panic happens because `debug_infos` does not contain a value while `values` does.

The only difference that I think could explain the panic is that `SyntaxNodeRef` values are not always equal when their `index`es are. Looking at the code, I don't really see how that could happen, unless `tree-sitter` gives us something incorrect.

## "Solution"

I've changed the code now so that both maps use the same key (the index, instead of the whole `SyntaxNodeRef`), and made it more obvious that we add elements to both maps at the same time.

It would be nice to understand what really goes wrong here, but I cannot reliably reproduce the error, so debugging is difficult.