### PR TITLE
Lazy node creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.11.0 -- 2023-07-12
+
+#### Changed
+
+- Node creation in lazy evaluation is now lazy instead of eager. Nodes that are not used, for example in edge or attribute statements, will not be part of the graph. Unused nodes can be included by setting `ExecutionConfig::include_unused_nodes`.
+
 ## v0.10.5 -- 2023-06-26
 
 #### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ features = ["std", "inline-more", "backends"]
 env_logger = "0.9"
 indoc = "1.0"
 tree-sitter-python = "0.19.1"
+pretty_assertions = "1.4"
 
 # cli-only dependencies below
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.10.5"
+version = "0.11.0"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -254,6 +254,7 @@ pub struct ExecutionConfig<'a, 'g> {
     pub(crate) functions: &'a Functions,
     pub(crate) globals: &'a Globals<'g>,
     pub(crate) lazy: bool,
+    pub(crate) include_unused_nodes: bool,
     pub(crate) location_attr: Option<Identifier>,
     pub(crate) variable_name_attr: Option<Identifier>,
 }
@@ -264,6 +265,7 @@ impl<'a, 'g> ExecutionConfig<'a, 'g> {
             functions,
             globals,
             lazy: false,
+            include_unused_nodes: false,
             location_attr: None,
             variable_name_attr: None,
         }
@@ -278,16 +280,32 @@ impl<'a, 'g> ExecutionConfig<'a, 'g> {
             functions: self.functions,
             globals: self.globals,
             lazy: self.lazy,
+            include_unused_nodes: self.include_unused_nodes,
             location_attr: location_attr.into(),
             variable_name_attr: variable_name_attr.into(),
         }
     }
 
+    /// Use lazy execution strategy. By default eager execution is used.
     pub fn lazy(self, lazy: bool) -> Self {
         Self {
             functions: self.functions,
             globals: self.globals,
             lazy,
+            include_unused_nodes: self.include_unused_nodes,
+            location_attr: self.location_attr,
+            variable_name_attr: self.variable_name_attr,
+        }
+    }
+
+    /// Include unused nodes in the graph when using lazy execution. By default,
+    /// unused nodes are not included.
+    pub fn include_unused_nodes(self, include_unused_nodes: bool) -> Self {
+        Self {
+            functions: self.functions,
+            globals: self.globals,
+            lazy: self.lazy,
+            include_unused_nodes,
             location_attr: self.location_attr,
             variable_name_attr: self.variable_name_attr,
         }

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -58,6 +58,7 @@ impl ast::File {
             functions: config.functions,
             globals: &globals,
             lazy: config.lazy,
+            include_unused_nodes: config.include_unused_nodes,
             location_attr: config.location_attr.clone(),
             variable_name_attr: config.variable_name_attr.clone(),
         };
@@ -103,7 +104,7 @@ impl ast::File {
         // Make sure any unforced values are now forced, to surface any problems
         // hidden by the fact that the values were unused. Unused nodes are not
         // created to avoid clutter in the graph.
-        store.force_all(&mut exec, false)?;
+        store.force_all(&mut exec, config.include_unused_nodes)?;
         scoped_store.force_all(&mut exec)?;
 
         Ok(())

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -79,6 +79,7 @@ impl File {
             functions: config.functions,
             globals: &globals,
             lazy: config.lazy,
+            include_unused_nodes: config.include_unused_nodes,
             location_attr: config.location_attr.clone(),
             variable_name_attr: config.variable_name_attr.clone(),
         };

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -6,7 +6,9 @@
 // ------------------------------------------------------------------------------------------------
 
 use indoc::indoc;
+use pretty_assertions::assert_eq;
 use tree_sitter::Parser;
+
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::ExecutionConfig;

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -6,7 +6,9 @@
 // ------------------------------------------------------------------------------------------------
 
 use indoc::indoc;
+use pretty_assertions::assert_eq;
 use tree_sitter::Parser;
+
 use tree_sitter_graph::ast::File;
 use tree_sitter_graph::functions::Functions;
 use tree_sitter_graph::ExecutionConfig;

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -6,7 +6,9 @@
 // ------------------------------------------------------------------------------------------------
 
 use indoc::indoc;
+use pretty_assertions::assert_eq;
 use tree_sitter::Parser;
+
 use tree_sitter_graph::graph::Graph;
 use tree_sitter_graph::graph::Value;
 use tree_sitter_graph::Identifier;

--- a/tests/it/parse_errors.rs
+++ b/tests/it/parse_errors.rs
@@ -6,9 +6,11 @@
 // ------------------------------------------------------------------------------------------------
 
 use indoc::indoc;
+use pretty_assertions::assert_eq;
 use tree_sitter::Parser;
 use tree_sitter::Point;
 use tree_sitter::Tree;
+
 use tree_sitter_graph::parse_error::ParseError;
 
 fn init_log() {

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -5,6 +5,7 @@
 // Please see the LICENSE-APACHE or LICENSE-MIT files in this distribution for license details.
 // ------------------------------------------------------------------------------------------------
 
+use pretty_assertions::assert_eq;
 use tree_sitter::CaptureQuantifier::*;
 
 use tree_sitter_graph::ast::*;


### PR DESCRIPTION
This PR changes node creation in lazy execution mode to be lazy instead of eager. Previously, all nodes were created and added to the graph, regardless of whether they were used.

Having the option to exclude unused nodes from the graph can make it easier to defined commonly used nodes on all syntax nodes, with something like this:

    (_)@node {
        node @node.one_node
        node @node.another_node
        ...
    }

