### PR TITLE
Add `match_node_attr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.11.0 -- 2023-07-17
+
+### Library
+
+#### Added
+
+- Store a debug attribute for the matched syntax node, providing information about the syntactic category of the match that gave rise to the graph node.
+
 ## v0.10.5 -- 2023-06-26
 
 #### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.10.5"
+version = "0.11.0"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To use it as a library, add the following to your `Cargo.toml`:
 
 ``` toml
 [dependencies]
-tree-sitter-graph = "0.10"
+tree-sitter-graph = "0.11"
 ```
 
 To use it as a program, install it via `cargo install`:

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -256,6 +256,7 @@ pub struct ExecutionConfig<'a, 'g> {
     pub(crate) lazy: bool,
     pub(crate) location_attr: Option<Identifier>,
     pub(crate) variable_name_attr: Option<Identifier>,
+    pub(crate) match_node_attr: Option<Identifier>,
 }
 
 impl<'a, 'g> ExecutionConfig<'a, 'g> {
@@ -266,6 +267,7 @@ impl<'a, 'g> ExecutionConfig<'a, 'g> {
             lazy: false,
             location_attr: None,
             variable_name_attr: None,
+            match_node_attr: None,
         }
     }
 
@@ -273,6 +275,7 @@ impl<'a, 'g> ExecutionConfig<'a, 'g> {
         self,
         location_attr: Identifier,
         variable_name_attr: Identifier,
+        match_node_attr: Identifier,
     ) -> Self {
         Self {
             functions: self.functions,
@@ -280,6 +283,7 @@ impl<'a, 'g> ExecutionConfig<'a, 'g> {
             lazy: self.lazy,
             location_attr: location_attr.into(),
             variable_name_attr: variable_name_attr.into(),
+            match_node_attr: match_node_attr.into(),
         }
     }
 
@@ -290,6 +294,7 @@ impl<'a, 'g> ExecutionConfig<'a, 'g> {
             lazy,
             location_attr: self.location_attr,
             variable_name_attr: self.variable_name_attr,
+            match_node_attr: self.match_node_attr,
         }
     }
 }


### PR DESCRIPTION
This PR adds a new match node attribute to support better debugging. The node being stored is the syntax node that was matched on to give rise to the graph node in question.