### PR TITLE
Dependency version cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ jobs:
 
     steps:
       - name: Install Rust environment
-        uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: ${{ matrix.rust }}
+        run: |
+          rustup toolchain install stable nightly
+          rustup default stable
+          cargo install cargo-hack cargo-minimal-versions
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Check formatting
@@ -37,9 +38,9 @@ jobs:
         run: cargo build
       - name: Test library (default features)
         run: cargo test
-      - name: Build library (all features)
-        run: cargo build --all-features
-      - name: Test library (all features)
-        run: cargo test --all-features
-      - name: Build program
-        run: cargo build --bin tree-sitter-graph --features=cli
+      - name: Build library (all feature combinations)
+        run: cargo hack --feature-powerset --no-dev-deps build
+      - name: Test library (all feature combinations)
+        run: cargo hack --feature-powerset test
+      - name: Build library (minimal versions)
+        run: cargo minimal-versions build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,12 @@ jobs:
 
     steps:
       - name: Install Rust environment
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: ${{ matrix.rust }}
+      - name: Install Cargo plugins
         run: |
-          rustup toolchain install stable nightly
-          rustup default stable
+          rustup toolchain install nightly
           cargo install cargo-hack cargo-minimal-versions
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
           key: ${{ runner.OS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.OS }}-cargo-
-      - name: Build library (default features)
-        run: cargo build
-      - name: Test library (default features)
-        run: cargo test
       - name: Build library (all feature combinations)
         run: cargo hack --feature-powerset --no-dev-deps build
       - name: Test library (all feature combinations)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,17 +29,17 @@ clap = { version = "3.2", optional = true }
 colored = { version = "2", optional = true }
 env_logger = { version = "0.9", optional = true }
 log = "0.4"
-regex = "1"
+regex = "1.3.2"
 serde = "1.0"
 serde_json = "1.0"
 smallvec = { version="1.6", features=["union"] }
 string-interner = { version = "0.12", default-features = false, features = ["std", "inline-more", "backends"] }
-thiserror = "1.0"
-tree-sitter = "0.20"
+thiserror = "1.0.7"
+tree-sitter = "0.20.3"
 tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-loader = { version = "0.19", optional = true }
+tree-sitter-loader = { version = "0.20", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9"
 indoc = "1.0"
-tree-sitter-python = "0.19"
+tree-sitter-python = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,27 +15,6 @@ edition = "2018"
 # All of our tests are in the tests/it "integration" test executable.
 test = false
 
-[dependencies]
-log = "0.4"
-regex = "1"
-serde = "1.0"
-serde_json = "1.0"
-smallvec = { version="1.6", features=["union"] }
-thiserror = "1.0"
-tree-sitter = "0.20"
-
-[dependencies.string-interner]
-version = "0.12"
-default-features = false
-features = ["std", "inline-more", "backends"]
-
-[dev-dependencies]
-env_logger = "0.9"
-indoc = "1.0"
-tree-sitter-python = "0.19.1"
-
-# cli-only dependencies below
-
 [[bin]]
 name = "tree-sitter-graph"
 required-features = ["cli"]
@@ -44,26 +23,23 @@ required-features = ["cli"]
 cli = ["anyhow", "clap", "env_logger", "term-colors", "tree-sitter-config", "tree-sitter-loader"]
 term-colors = ["colored"]
 
-[dependencies.anyhow]
-optional = true
-version = "1.0"
+[dependencies]
+anyhow = { version = "1.0", optional = true }
+clap = { version = "3.2", optional = true }
+colored = { version = "2", optional = true }
+env_logger = { version = "0.9", optional = true }
+log = "0.4"
+regex = "1"
+serde = "1.0"
+serde_json = "1.0"
+smallvec = { version="1.6", features=["union"] }
+string-interner = { version = "0.12", default-features = false, features = ["std", "inline-more", "backends"] }
+thiserror = "1.0"
+tree-sitter = "0.20"
+tree-sitter-config = { version = "0.19", optional = true }
+tree-sitter-loader = { version = "0.19", optional = true }
 
-[dependencies.clap]
-optional = true
-version = "3.2"
-
-[dependencies.colored]
-optional = true
-version = "2"
-
-[dependencies.env_logger]
-optional = true
-version = "0.9"
-
-[dependencies.tree-sitter-config]
-optional = true
-version = "0.19"
-
-[dependencies.tree-sitter-loader]
-optional = true
-version = "0.19"
+[dev-dependencies]
+env_logger = "0.9"
+indoc = "1.0"
+tree-sitter-python = "0.19"

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -575,7 +575,7 @@ pub mod stdlib {
                 let replacement = parameters.param()?.into_string()?;
                 parameters.finish()?;
                 Ok(Value::String(
-                    pattern.replace_all(&text, replacement).to_string(),
+                    pattern.replace_all(&text, replacement.as_str()).to_string(),
                 ))
             }
         }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -104,7 +104,7 @@ impl<V> MutVariables<V> for VariableMap<'_, V> {
                     v.into_key().to_string(),
                 ))),
             Occupied(mut o) => {
-                let mut variable = o.get_mut();
+                let variable = o.get_mut();
                 if variable.mutable {
                     variable.value = value;
                     Ok(())


### PR DESCRIPTION
Cleanup of dependencies after users reported issues in a dependent crate (github/stack-graphs#407).

Main changes:

- Reformatted `Cargo.toml` to be more compact.
- Include minimal required patch version in `tree-sitter` dependency.
- Test whether the library builds correctly with the minimal support dependency versions.
- Test whether the library builds and passes tests with all possible feature combinations.
- Bump patch version for release.