### PR TITLE
Release tree-sitter-graph v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.11.1 -- 2024-03-06
+
+Updated the `tree-sitter` dependency to include the required minimal patch version.
+
 ## v0.11.0 -- 2023-07-17
 
 ### Library

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.11.0"
+version = "0.11.1"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"


### PR DESCRIPTION
I forgot to push the commit which actually bumped the version yesterday. Let's try again.
