### PR TITLE
Allow duplicate edges and attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### DSL
+
+#### Added
+
+- Support adding an edge multiple times, or setting an attribute multiple times with the same value. Previously these would raise runtime errors.
+
 ## v0.11.1 -- 2024-03-06
 
 Updated the `tree-sitter` dependency to include the required minimal patch version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.11.2 -- 2024-03-08
 
 ### DSL
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree-sitter-graph"
-version = "0.11.1"
+version = "0.11.2"
 description = "Construct graphs from parsed source code"
 homepage = "https://github.com/tree-sitter/tree-sitter-graph/"
 repository = "https://github.com/tree-sitter/tree-sitter-graph/"

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -165,7 +165,6 @@ pub(self) struct EvaluationContext<'a, 'tree> {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(super) enum GraphElementKey {
     NodeAttribute(graph::GraphNodeRef, Identifier),
-    Edge(graph::GraphNodeRef, graph::GraphNodeRef),
     EdgeAttribute(graph::GraphNodeRef, graph::GraphNodeRef, Identifier),
 }
 

--- a/src/execution/lazy/statements.rs
+++ b/src/execution/lazy/statements.rs
@@ -226,24 +226,8 @@ impl LazyCreateEdge {
             .sink
             .evaluate_as_graph_node(exec)
             .with_context(|| "Evaluating edge sink".to_string().into())?;
-        let prev_debug_info = exec
-            .prev_element_debug_info
-            .insert(GraphElementKey::Edge(source, sink), self.debug_info.clone());
         let edge = match exec.graph[source].add_edge(sink) {
-            Ok(edge) => edge,
-            Err(_) => {
-                return Err(ExecutionError::DuplicateEdge(format!(
-                    "({} -> {})",
-                    source, sink,
-                )))
-                .with_context(|| {
-                    (
-                        prev_debug_info.unwrap().into(),
-                        self.debug_info.clone().into(),
-                    )
-                        .into()
-                });
-            }
+            Ok(edge) | Err(edge) => edge,
         };
         edge.attributes = self.attributes.clone();
         Ok(())

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -334,13 +334,7 @@ impl CreateEdge {
         let source = self.source.evaluate(exec)?.into_graph_node_ref()?;
         let sink = self.sink.evaluate(exec)?.into_graph_node_ref()?;
         let edge = match exec.graph[source].add_edge(sink) {
-            Ok(edge) => edge,
-            Err(_) => {
-                return Err(ExecutionError::DuplicateEdge(format!(
-                    "({} -> {}) in {}",
-                    source, sink, self,
-                )))?
-            }
+            Ok(edge) | Err(edge) => edge,
         };
         self.add_debug_attrs(&mut edge.attributes, exec.config)?;
         Ok(())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -275,11 +275,15 @@ impl Attributes {
 
     /// Adds an attribute to this attribute set.  If there was already an attribute with the same
     /// name, replaces its value and returns `Err`.
-    pub fn add<V: Into<Value>>(&mut self, name: Identifier, value: V) -> Result<(), ()> {
+    pub fn add<V: Into<Value>>(&mut self, name: Identifier, value: V) -> Result<(), Value> {
         match self.values.entry(name) {
             Entry::Occupied(mut o) => {
-                o.insert(value.into());
-                Err(())
+                let value = value.into();
+                if o.get() != &value {
+                    Err(o.insert(value.into()))
+                } else {
+                    Ok(())
+                }
             }
             Entry::Vacant(v) => {
                 v.insert(value.into());

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -1008,3 +1008,67 @@ fn cannot_access_non_inherited_variable() {
         "#},
     );
 }
+
+#[test]
+fn can_add_edge_twice() {
+    check_execution(
+        indoc! { r#"
+            pass
+        "#},
+        indoc! {r#"
+            (module) {
+              node n1;
+              node n2;
+              edge n1 -> n2;
+              edge n1 -> n2;
+            }
+        "#},
+        indoc! {r#"
+          node 0
+          edge 0 -> 1
+          node 1
+        "#},
+    );
+}
+
+#[test]
+fn can_set_node_attribute_value_twice() {
+    check_execution(
+        indoc! { r#"
+            pass
+        "#},
+        indoc! {r#"
+            (module) {
+              node n;
+              attr (n) foo = #true;
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            foo: #true
+        "#},
+    );
+}
+
+#[test]
+fn cannot_change_attribute_value() {
+    check_execution(
+        indoc! { r#"
+            pass
+        "#},
+        indoc! {r#"
+            (module) {
+              node n1;
+              node n2;
+              edge n1 -> n2;
+              attr (n1 -> n2) foo = #true;
+            }
+        "#},
+        indoc! {r#"
+          node 0
+          edge 0 -> 1
+            foo: #true
+          node 1
+        "#},
+    );
+}

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -1527,3 +1527,67 @@ fn cannot_access_non_inherited_variable() {
         "#},
     );
 }
+
+#[test]
+fn can_add_edge_twice() {
+    check_execution(
+        indoc! { r#"
+            pass
+        "#},
+        indoc! {r#"
+            (module) {
+              node n1;
+              node n2;
+              edge n1 -> n2;
+              edge n1 -> n2;
+            }
+        "#},
+        indoc! {r#"
+          node 0
+          edge 0 -> 1
+          node 1
+        "#},
+    );
+}
+
+#[test]
+fn can_set_node_attribute_value_twice() {
+    check_execution(
+        indoc! { r#"
+            pass
+        "#},
+        indoc! {r#"
+            (module) {
+              node n;
+              attr (n) foo = #true;
+            }
+        "#},
+        indoc! {r#"
+          node 0
+            foo: #true
+        "#},
+    );
+}
+
+#[test]
+fn cannot_change_attribute_value() {
+    check_execution(
+        indoc! { r#"
+            pass
+        "#},
+        indoc! {r#"
+            (module) {
+              node n1;
+              node n2;
+              edge n1 -> n2;
+              attr (n1 -> n2) foo = #true;
+            }
+        "#},
+        indoc! {r#"
+          node 0
+          edge 0 -> 1
+            foo: #true
+          node 1
+        "#},
+    );
+}


### PR DESCRIPTION
Relaxes runtime checks so that setting an edge multiple times, or setting attributes to the same value multiple times, is no longer an error.

Fixes #85 and #93.

If we allow this for edges and attributes, it makes sense to also allow this for `node @capture.name` occurring multiple times for the same syntax node. I've not addressed that here because implementing that is more involved and requires tracking some extra bookkeeping during execution. 
