### PR TITLE
PR: Updating to sync with tree-sitter 0.22.2 (and tests with tree-sitter-python 0.21)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = "1.0"
 smallvec = { version="1.6", features=["union"] }
 string-interner = { version = "0.12", default-features = false, features = ["std", "inline-more", "backends"] }
 thiserror = "1.0.7"
-tree-sitter = "0.20.3"
+tree-sitter = "0.22.2"
 tree-sitter-config = { version = "0.19", optional = true }
 tree-sitter-loader = { version = "0.20", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ tree-sitter-loader = { version = "0.20", optional = true }
 [dev-dependencies]
 env_logger = "0.9"
 indoc = "1.0"
-tree-sitter-python = "0.20"
+tree-sitter-python =  "0.21.0"

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -188,7 +188,7 @@ impl ast::Stanza {
                     .expect("capture should have index")
                     != self.full_match_stanza_capture_index as u32
             })
-            .map(|cn| Identifier::from(cn.as_str()))
+            .map(|cn| Identifier::from(*cn))
             .collect::<HashSet<_>>();
         let unused_captures = all_captures
             .difference(&used_captures)

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -146,7 +146,7 @@ impl File {
                             .capture_index_for_name(name)
                             .expect("missing index for capture");
                         let quantifier = stanza.query.capture_quantifiers(0)[index as usize];
-                        (name, quantifier, index)
+                        (name.to_string(), quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_stanza_capture_index as u32)
                     .collect();
@@ -182,7 +182,7 @@ impl Stanza {
                         .capture_index_for_name(name)
                         .expect("missing index for capture");
                     let quantifier = self.query.capture_quantifiers(0)[index as usize];
-                    (name, quantifier, index)
+                    (name.to_string(), quantifier, index)
                 })
                 .filter(|c| c.2 != self.full_match_stanza_capture_index as u32)
                 .collect();

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -123,7 +123,7 @@ impl File {
                             .expect("missing index for capture");
                         let quantifier =
                             file_query.capture_quantifiers(mat.pattern_index)[index as usize];
-                        (&name.to_string().to_owned(), quantifier, index)
+                        (name.to_string(), quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_file_capture_index as u32)
                     .collect();
@@ -146,7 +146,7 @@ impl File {
                             .capture_index_for_name(name)
                             .expect("missing index for capture");
                         let quantifier = stanza.query.capture_quantifiers(0)[index as usize];
-                        (&name.to_string().to_owned(), quantifier, index)
+                        (name.to_string(), quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_stanza_capture_index as u32)
                     .collect();
@@ -172,19 +172,18 @@ impl Stanza {
         F: FnMut(Match<'_, 'tree>) -> Result<(), E>,
     {
         self.try_visit_matches_strict(tree, source, |mat| {
-            let named_captures = self
+            let named_captures : Vec<(String,CaptureQuantifier,u32)> = self
                 .query
                 .capture_names()
                 .iter()
                 .flat_map(|name| {
                     if let Some(index) = self.query.capture_index_for_name(name) {
                         let quantifier = self.query.capture_quantifiers(0)[index as usize];
-                        Some ((name,quantifier,index))
+                        Some ((name.to_string(),quantifier,index))
                     } else {
                         None
                     }
                 })
-                .map(|(name,quantifier,index)| (&name.to_string(), quantifier, index))
                 .filter(|c| c.2 != self.full_match_stanza_capture_index as u32)
                 .collect();
             visit(Match {
@@ -200,7 +199,7 @@ impl Stanza {
 pub struct Match<'a, 'tree> {
     mat: QueryMatch<'a, 'tree>,
     full_capture_index: u32,
-    named_captures: Vec<(&'a String, CaptureQuantifier, u32)>,
+    named_captures: Vec<(String, CaptureQuantifier, u32)>,
     query_location: Location,
 }
 
@@ -218,14 +217,14 @@ impl<'a, 'tree> Match<'a, 'tree> {
         &'s self,
     ) -> impl Iterator<
         Item = (
-            &String,
+            String,
             CaptureQuantifier,
             impl Iterator<Item = Node<'tree>> + 's,
         ),
     > {
         self.named_captures
             .iter()
-            .map(move |c| (c.0, c.1, self.mat.nodes_for_capture_index(c.2)))
+            .map(move |c| (c.0.clone(), c.1, self.mat.nodes_for_capture_index(c.2)))
     }
 
     /// Return the matched nodes for a named capture.
@@ -240,8 +239,8 @@ impl<'a, 'tree> Match<'a, 'tree> {
     }
 
     /// Return an iterator over all capture names.
-    pub fn capture_names(&self) -> impl Iterator<Item = &String> {
-        self.named_captures.iter().map(|c| c.0)
+    pub fn capture_names(&self) -> impl Iterator<Item = String> + '_ {
+        self.named_captures.iter().map(|c| c.0.clone())
     }
 
     /// Return the query location.

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -123,7 +123,7 @@ impl File {
                             .expect("missing index for capture");
                         let quantifier =
                             file_query.capture_quantifiers(mat.pattern_index)[index as usize];
-                        (name, quantifier, index)
+                        (&name.to_string().to_owned(), quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_file_capture_index as u32)
                     .collect();
@@ -146,7 +146,7 @@ impl File {
                             .capture_index_for_name(name)
                             .expect("missing index for capture");
                         let quantifier = stanza.query.capture_quantifiers(0)[index as usize];
-                        (name.to_string(), quantifier, index)
+                        (&name.to_string().to_owned(), quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_stanza_capture_index as u32)
                     .collect();

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -176,14 +176,15 @@ impl Stanza {
                 .query
                 .capture_names()
                 .iter()
-                .map(|name| {
-                    let index = self
-                        .query
-                        .capture_index_for_name(name)
-                        .expect("missing index for capture");
-                    let quantifier = self.query.capture_quantifiers(0)[index as usize];
-                    (name.to_string(), quantifier, index)
+                .flat_map(|name| {
+                    if let Some(index) = self.query.capture_index_for_name(name) {
+                        let quantifier = self.query.capture_quantifiers(0)[index as usize];
+                        Some ((name,quantifier,index))
+                    } else {
+                        None
+                    }
                 })
+                .map(|(name,quantifier,index)| (&name.to_string(), quantifier, index))
                 .filter(|c| c.2 != self.full_match_stanza_capture_index as u32)
                 .collect();
             visit(Match {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -311,7 +311,7 @@ impl<'a> Parser<'a> {
             self.consume_whitespace();
         }
         // we can unwrap here because all queries have already been parsed before
-        file.query = Some(Query::new(file.language, &self.query_source).unwrap());
+        file.query = Some(Query::new(&file.language, &self.query_source).unwrap());
         Ok(())
     }
 
@@ -395,7 +395,7 @@ impl<'a> Parser<'a> {
         // the global query_source.
         self.query_source += &query_source;
         self.query_source += "\n";
-        let query = Query::new(language, &query_source).map_err(|mut e| {
+        let query = Query::new(&language, &query_source).map_err(|mut e| {
             // the column of the first row of a query pattern must be shifted by the whitespace
             // that was already consumed
             if e.row == 0 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,7 +305,7 @@ impl<'a> Parser<'a> {
                 let name = self.parse_identifier("inherit")?;
                 file.inherited_variables.insert(name);
             } else {
-                let stanza = self.parse_stanza(file.language)?;
+                let stanza = self.parse_stanza(file.language.clone())?;
                 file.stanzas.push(stanza);
             }
             self.consume_whitespace();

--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -27,7 +27,7 @@ fn init_log() {
 fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionError> {
     init_log();
     let mut parser = Parser::new();
-    parser.set_language(tree_sitter_python::language()).unwrap();
+    parser.set_language(&tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();
     let file =
         File::from_str(tree_sitter_python::language(), dsl_source).expect("Cannot parse file");

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -27,7 +27,7 @@ fn init_log() {
 fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionError> {
     init_log();
     let mut parser = Parser::new();
-    parser.set_language(tree_sitter_python::language()).unwrap();
+    parser.set_language(&tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();
     let file =
         File::from_str(tree_sitter_python::language(), dsl_source).expect("Cannot parse file");

--- a/tests/it/graph.rs
+++ b/tests/it/graph.rs
@@ -51,7 +51,7 @@ fn can_iterate_graph_edges() {
 fn can_display_graph() {
     let python_source = "pass";
     let mut parser = Parser::new();
-    parser.set_language(tree_sitter_python::language()).unwrap();
+    parser.set_language(&tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();
 
     let mut graph = Graph::new();

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -26,7 +26,7 @@ fn init_log() {
 fn execute(python_source: &str, dsl_source: &str) -> Result<String, ExecutionError> {
     init_log();
     let mut parser = Parser::new();
-    parser.set_language(tree_sitter_python::language()).unwrap();
+    parser.set_language(&tree_sitter_python::language()).unwrap();
     let tree = parser.parse(python_source, None).unwrap();
     let file =
         File::from_str(tree_sitter_python::language(), dsl_source).expect("Cannot parse file");

--- a/tests/it/parse_errors.rs
+++ b/tests/it/parse_errors.rs
@@ -23,7 +23,7 @@ fn init_log() {
 fn parse(python_source: &str) -> Tree {
     init_log();
     let mut parser = Parser::new();
-    parser.set_language(tree_sitter_python::language()).unwrap();
+    parser.set_language(&tree_sitter_python::language()).unwrap();
     parser.parse(python_source, None).unwrap()
 }
 


### PR DESCRIPTION
Trying to use the latest library, I encountered a few problems with some versions, so this PR has a few changes (str/String iterators mostly) that allow the tree-sitter-graph library to be compatible with more recent versions of tree-sitter and other languages (tested against tree-sitter-python). 