### PR TITLE
Allow optional globals be omitted

### DIFF
--- a/tests/it/execution.rs
+++ b/tests/it/execution.rs
@@ -291,6 +291,28 @@ fn can_omit_global_variable_with_default() {
 }
 
 #[test]
+fn can_omit_optional_global_variable() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          global pkgname?
+
+          (module)
+          {
+            node n
+            if (is-null pkgname) {
+              attr (n) pkgname = "fallback"
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            pkgname: "fallback"
+    "#},
+    );
+}
+
+#[test]
 fn cannot_omit_global_variable() {
     fail_execution(
         "pass",

--- a/tests/it/lazy_execution.rs
+++ b/tests/it/lazy_execution.rs
@@ -292,6 +292,28 @@ fn can_omit_global_variable_with_default() {
 }
 
 #[test]
+fn can_omit_optional_global_variable() {
+    check_execution(
+        "pass",
+        indoc! {r#"
+          global pkgname?
+
+          (module)
+          {
+            node n
+            if (is-null pkgname) {
+              attr (n) pkgname = "fallback"
+            }
+          }
+        "#},
+        indoc! {r#"
+          node 0
+            pkgname: "fallback"
+    "#},
+    );
+}
+
+#[test]
 fn cannot_omit_global_variable() {
     fail_execution(
         "pass",


### PR DESCRIPTION
When defining an optional global, currently the library still requires that it be set in the [`ExecutionConfig::globals`][] passed to [`File::execute`][], or it fails with an [`ExecutionError(MissingGlobalVariable("MY_GLOBAL"))`][err]. This change allows the global to be omitted:


```tsg
constant MY_GLOBAL?
```

```rust
let globals = Variables::new(); // Empty; `MY_GLOBAL` does not need to be set
let config = ExecutionConfig::new(&functions, &globals);
let graph = file.execute(tree, source, &config, &NoCancellation)?;
```

[`ExecutionConfig::globals`]: https://github.com/tree-sitter/tree-sitter-graph/blob/v0.11.2/src/execution.rs#L255
[`File::execute`]: https://github.com/tree-sitter/tree-sitter-graph/blob/v0.11.2/src/execution.rs#L35
[err]: https://github.com/tree-sitter/tree-sitter-graph/blob/v0.11.2/src/execution/error.rs#L51