### PR TITLE
update tree-sitter dependency to 22.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,11 @@ serde_json = "1.0"
 smallvec = { version="1.6", features=["union"] }
 string-interner = { version = "0.12", default-features = false, features = ["std", "inline-more", "backends"] }
 thiserror = "1.0.7"
-tree-sitter = "0.20.3"
-tree-sitter-config = { version = "0.19", optional = true }
-tree-sitter-loader = { version = "0.20", optional = true }
+tree-sitter = "0.22.6"
+tree-sitter-config = { version = "0.22.6", optional = true }
+tree-sitter-loader = { version = "0.22.6", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9"
 indoc = "1.0"
-tree-sitter-python = "0.20"
+tree-sitter-python = "0.21"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -21,8 +21,8 @@ use crate::Location;
 
 /// A graph DSL file
 #[derive(Debug)]
-pub struct File {
-    pub language: Language,
+pub struct File<'a> {
+    pub language: &'a Language,
     /// The expected global variables used in this file
     pub globals: Vec<Global>,
     /// The scoped variables that are inherited by child nodes
@@ -35,8 +35,8 @@ pub struct File {
     pub shorthands: AttributeShorthands,
 }
 
-impl File {
-    pub fn new(language: Language) -> File {
+impl<'a> File<'a> {
+    pub fn new(language: &'a Language) -> File {
         File {
             language,
             globals: Vec::new(),

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
         )?;
     }
 
-    let config = Config::load()?;
+    let config = Config::load(None)?;
     let mut loader = Loader::new()?;
     let loader_config = config.get()?;
     loader.find_all_languages(&loader_config)?;
@@ -98,7 +98,7 @@ fn main() -> Result<()> {
     let tsg = std::fs::read(tsg_path)
         .with_context(|| format!("Cannot read TSG file {}", tsg_path.display()))?;
     let tsg = String::from_utf8(tsg)?;
-    let file = match File::from_str(language, &tsg) {
+    let file = match File::from_str(&language, &tsg) {
         Ok(file) => file,
         Err(err) => {
             eprintln!("{}", err.display_pretty(tsg_path, &tsg));
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
         .with_context(|| format!("Cannot read source file {}", source_path.display()))?;
     let source = String::from_utf8(source)?;
     let mut parser = Parser::new();
-    parser.set_language(language)?;
+    parser.set_language(&language)?;
     let tree = parser
         .parse(&source, None)
         .ok_or_else(|| anyhow!("Cannot parse {}", source_path.display()))?;

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -121,7 +121,7 @@ struct VariableResult {
 //-----------------------------------------------------------------------------
 // File
 
-impl ast::File {
+impl ast::File<'_> {
     pub fn check(&mut self) -> Result<(), CheckError> {
         let mut globals = VariableMap::new();
         for global in &self.globals {
@@ -188,7 +188,7 @@ impl ast::Stanza {
                     .expect("capture should have index")
                     != self.full_match_stanza_capture_index as u32
             })
-            .map(|cn| Identifier::from(cn.as_str()))
+            .map(|cn| Identifier::from(*cn))
             .collect::<HashSet<_>>();
         let unused_captures = all_captures
             .difference(&used_captures)

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -28,7 +28,7 @@ pub(crate) mod error;
 mod lazy;
 mod strict;
 
-impl File {
+impl File<'_> {
     /// Executes this graph DSL file against a source file.  You must provide the parsed syntax
     /// tree (`tree`) as well as the source text that it was parsed from (`source`).  You also
     /// provide the set of functions and global variables that are available during execution.
@@ -123,7 +123,7 @@ impl File {
                             .expect("missing index for capture");
                         let quantifier =
                             file_query.capture_quantifiers(mat.pattern_index)[index as usize];
-                        (name, quantifier, index)
+                        (*name, quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_file_capture_index as u32)
                     .collect();
@@ -146,7 +146,7 @@ impl File {
                             .capture_index_for_name(name)
                             .expect("missing index for capture");
                         let quantifier = stanza.query.capture_quantifiers(0)[index as usize];
-                        (name, quantifier, index)
+                        (*name, quantifier, index)
                     })
                     .filter(|c| c.2 != stanza.full_match_stanza_capture_index as u32)
                     .collect();
@@ -182,7 +182,7 @@ impl Stanza {
                         .capture_index_for_name(name)
                         .expect("missing index for capture");
                     let quantifier = self.query.capture_quantifiers(0)[index as usize];
-                    (name, quantifier, index)
+                    (*name, quantifier, index)
                 })
                 .filter(|c| c.2 != self.full_match_stanza_capture_index as u32)
                 .collect();
@@ -199,7 +199,7 @@ impl Stanza {
 pub struct Match<'a, 'tree> {
     mat: QueryMatch<'a, 'tree>,
     full_capture_index: u32,
-    named_captures: Vec<(&'a String, CaptureQuantifier, u32)>,
+    named_captures: Vec<(&'a str, CaptureQuantifier, u32)>,
     query_location: Location,
 }
 
@@ -217,7 +217,7 @@ impl<'a, 'tree> Match<'a, 'tree> {
         &'s self,
     ) -> impl Iterator<
         Item = (
-            &String,
+            &str,
             CaptureQuantifier,
             impl Iterator<Item = Node<'tree>> + 's,
         ),
@@ -239,7 +239,7 @@ impl<'a, 'tree> Match<'a, 'tree> {
     }
 
     /// Return an iterator over all capture names.
-    pub fn capture_names(&self) -> impl Iterator<Item = &String> {
+    pub fn capture_names(&self) -> impl Iterator<Item = &str> {
         self.named_captures.iter().map(|c| c.0)
     }
 

--- a/src/execution/lazy.rs
+++ b/src/execution/lazy.rs
@@ -38,7 +38,7 @@ use statements::*;
 use store::*;
 use values::*;
 
-impl ast::File {
+impl ast::File <'_> {
     /// Executes this graph DSL file against a source file, saving the results into an existing
     /// `Graph` instance.  You must provide the parsed syntax tree (`tree`) as well as the source
     /// text that it was parsed from (`source`).  You also provide the set of functions and global

--- a/src/execution/strict.rs
+++ b/src/execution/strict.rs
@@ -59,7 +59,7 @@ use crate::variables::Variables;
 use crate::Identifier;
 use crate::Location;
 
-impl File {
+impl File<'_> {
     /// Executes this graph DSL file against a source file, saving the results into an existing
     /// `Graph` instance.  You must provide the parsed syntax tree (`tree`) as well as the source
     /// text that it was parsed from (`source`).  You also provide the set of functions and global

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,9 +28,9 @@ use crate::Identifier;
 
 pub const FULL_MATCH: &str = "__tsg__full_match";
 
-impl ast::File {
+impl <'a> ast::File<'a> {
     /// Parses a graph DSL file, returning a new `File` instance.
-    pub fn from_str(language: Language, source: &str) -> Result<Self, ParseError> {
+    pub fn from_str(language: &'a Language, source: &str) -> Result<Self, ParseError> {
         let mut file = ast::File::new(language);
         #[allow(deprecated)]
         file.parse(source)?;
@@ -305,13 +305,13 @@ impl<'a> Parser<'a> {
                 let name = self.parse_identifier("inherit")?;
                 file.inherited_variables.insert(name);
             } else {
-                let stanza = self.parse_stanza(file.language)?;
+                let stanza = self.parse_stanza(&file.language)?;
                 file.stanzas.push(stanza);
             }
             self.consume_whitespace();
         }
         // we can unwrap here because all queries have already been parsed before
-        file.query = Some(Query::new(file.language, &self.query_source).unwrap());
+        file.query = Some(Query::new(&file.language, &self.query_source).unwrap());
         Ok(())
     }
 
@@ -369,7 +369,7 @@ impl<'a> Parser<'a> {
         Ok(quantifier)
     }
 
-    fn parse_stanza(&mut self, language: Language) -> Result<ast::Stanza, ParseError> {
+    fn parse_stanza(&mut self, language: &Language) -> Result<ast::Stanza, ParseError> {
         let start = self.location;
         let (query, full_match_stanza_capture_index) = self.parse_query(language)?;
         self.consume_whitespace();
@@ -385,7 +385,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_query(&mut self, language: Language) -> Result<(Query, usize), ParseError> {
+    fn parse_query(&mut self, language: &Language) -> Result<(Query, usize), ParseError> {
         let location = self.location;
         let query_start = self.offset;
         self.skip_query()?;


### PR DESCRIPTION
1. Upgrade dependency.
2. Change `struct File` to `struct File<'a>`, where `'a` used as the lifetime type parameter of member &language.
3. Change `named_captures` to `named_captures: Vec<(&'a str, CaptureQuantifier, u32)>`