### PR TITLE
fix(tree-sitter): support tree-sitter 0.26.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,11 @@ serde_json = "1.0"
 smallvec = { version="1.6", features=["union"] }
 streaming-iterator = "0.1.9"
 thiserror = "1.0.7"
-tree-sitter = "0.24"
-tree-sitter-config = { version = "0.24", optional = true }
-tree-sitter-loader = { version = "0.24", optional = true }
+tree-sitter = "0.26.7"
+tree-sitter-config = { version = "0.26.7", optional = true }
+tree-sitter-loader = { version = "0.26.7", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9"
 indoc = "1.0"
-tree-sitter-python = "=0.23.5"
+tree-sitter-python = "0.25.0"

--- a/src/bin/tree-sitter-graph/main.rs
+++ b/src/bin/tree-sitter-graph/main.rs
@@ -93,7 +93,8 @@ fn main() -> Result<()> {
     let mut loader = Loader::new()?;
     let loader_config = config.get()?;
     loader.find_all_languages(&loader_config)?;
-    let language = loader.select_language(source_path, &current_dir, matches.value_of("scope"))?;
+    let language =
+        loader.select_language(Some(source_path), &current_dir, matches.value_of("scope"), None)?;
 
     let tsg = std::fs::read(tsg_path)
         .with_context(|| format!("Cannot read TSG file {}", tsg_path.display()))?;


### PR DESCRIPTION
Update tree-sitter, tree-sitter-config, and tree-sitter-loader to 0.26.7 and bump the test grammar dependency.

Adjust the CLI loader.select_language call to the 0.26 API signature so all-features builds pass.